### PR TITLE
Use krb5 credential cache to get and store the TGT and the creds.

### DIFF
--- a/README
+++ b/README
@@ -100,14 +100,12 @@ KRB5 Authentication
 Kerberos authentication can be used when the linux workstation as well as
 the file server are part of Active Directory.
 
-Before you can use KRB5 authentication you must first authenticate to the KDC.
-Use "kinit username@YOUR-REALM" to do that in the normal way you set up
-kerberos.
-
-Once you have run kinit successfully you should be able to authenticate to the
-file server using krb5 by specifying sec=krb5 in the URL :
+You should be able to authenticate to the file server using krb5
+by specifying sec=krb5 in the URL :
   smb://server/share?sec=krb5
 
+The application needs to set the username, password and the domain fqdn in the context using
+smb2_set_user(), smb2_set_password() and smb2_set_domain() respectively.
 
 BUILTIN NTLMSSP
 ===============

--- a/lib/krb5-wrapper.c
+++ b/lib/krb5-wrapper.c
@@ -53,6 +53,8 @@
 #include <unistd.h>
 #endif
 
+#include <krb5/krb5.h>
+#include <gssapi/gssapi_krb5.h>
 #include <gssapi/gssapi.h>
 #include <stdio.h>
 
@@ -63,6 +65,13 @@
 #include "libsmb2-private.h"
 
 #include "krb5-wrapper.h"
+
+/** Global Definitions */
+krb5_context    krb5_cctx;
+krb5_ccache     krb5_Ccache;
+krb5_creds      krb5_ccreds;
+krb5_principal  client_princ;
+
 
 void
 krb5_free_auth_data(struct private_auth_data *auth)
@@ -137,6 +146,115 @@ krb5_set_gss_error(struct smb2_context *smb2, char *func,
         free(err_maj);
 }
 
+/** private function
+  A function to build the credentials cache, given the user and password and the realm.
+  By default it uses /etc/krb5.conf provided realm.
+  - This funtion gets the TGT, builds the cache and stores the creds in the cache.
+  - the user will have to call krb5_cc_get_name to get a name for the cache, gss_krb5_ccache_name to load the cache by name using
+  - gssapi.
+  - And then gss_krb5_import_cred to generate the gss creds instead of using gss_acquire_cred.
+  - So the no need to call kinit before using a client of this library
+ */
+int
+krb5_create_creds_cache(struct smb2_context *smb2, const char *user, const char *password)
+{
+    krb5_error_code ret = 0;
+    krb5_get_init_creds_opt *cred_opt;
+    int len;
+
+    if (user == NULL || password == NULL)
+    {
+      smb2_set_error(smb2, "User name/ Password not provided");
+      return -1;
+    }
+
+    if (smb2->domain == NULL)
+    {
+      smb2_set_error(smb2, "domain not set for kerberos authentication");
+      return -1;
+    }
+
+    client_princ = NULL;
+
+    ret = krb5_init_context(&krb5_cctx);
+    if (ret)
+    {
+      smb2_set_error(smb2, "Failed to initialize krb5 context - %s", krb5_get_error_message(krb5_cctx, ret));
+      return -1;
+    }
+
+    memset(&krb5_ccreds, 0, sizeof(krb5_ccreds));
+
+    ret = krb5_cc_new_unique(krb5_cctx, "MEMORY", NULL, &krb5_Ccache);
+    if (ret != 0)
+    {
+      smb2_set_error(smb2, "Failed to create krb5 credentials cache - %s", krb5_get_error_message(krb5_cctx, ret));
+      return -1;
+    }
+
+    len = strlen(smb2->domain);
+    ret = krb5_build_principal(krb5_cctx, &client_princ, len, smb2->domain, user, NULL);
+    //ret = krb5_parse_name(krb5_cctx, user, &client_princ);
+    if (ret)
+    {
+      smb2_set_error(smb2, "Failed to get the client principal - %s", krb5_get_error_message(krb5_cctx, ret));
+      return -1;
+    }
+
+    ret = krb5_cc_initialize(krb5_cctx, krb5_Ccache, client_princ);
+    if (ret != 0)
+    {
+      smb2_set_error(smb2, "Failed to initialize krb5 credentials cache for the principal - %s", krb5_get_error_message(krb5_cctx, ret));
+      return -1;
+    }
+
+    ret = krb5_get_init_creds_opt_alloc(krb5_cctx, &cred_opt);
+    if (ret != 0)
+    {
+      smb2_set_error(smb2, "Failed to get krb5 credentials cache options - %s", krb5_get_error_message(krb5_cctx, ret));
+      return -1;
+    }
+
+    ret = krb5_get_init_creds_password(krb5_cctx,
+                                       &krb5_ccreds,
+                                       client_princ, password,
+                                       0, NULL, 0, NULL, NULL);
+    if (ret != 0)
+    {
+      smb2_set_error(smb2, "krb5_get_init_creds_password: Failed to init credentials - %s", krb5_get_error_message(krb5_cctx, ret));
+      return -1;
+    }
+
+    ret= krb5_cc_store_cred(krb5_cctx, krb5_Ccache, &krb5_ccreds);
+    if (ret != 0)
+    {
+      smb2_set_error(smb2, "Failed to store the credentials in cache - %s", krb5_get_error_message(krb5_cctx, ret));
+      return -1;
+    }
+
+    return ret;
+}
+
+/** private function -
+  - To release the cache, creds and context
+ */
+int
+krb5_remove_creds_cache(struct private_auth_data *auth_data)
+{
+    //gss_release_cred(NULL, &auth_data->cred);
+
+    if (client_princ != NULL)
+      krb5_free_principal(krb5_cctx, client_princ);
+
+    krb5_free_cred_contents(krb5_cctx, &krb5_ccreds);
+    krb5_cc_destroy(krb5_cctx, krb5_Ccache);
+    krb5_free_context(krb5_cctx);
+    return 0;
+}
+
+// Enable thhis flag to use krb5 cached creds or else you need to do a kinit
+#define USE_CACHED_CREDS
+
 struct private_auth_data *
 krb5_negotiate_reply(struct smb2_context *smb2, const char *server,
                      const char *user_name) {
@@ -144,7 +262,11 @@ krb5_negotiate_reply(struct smb2_context *smb2, const char *server,
         gss_buffer_desc target = GSS_C_EMPTY_BUFFER;
         uint32_t maj, min;
         gss_buffer_desc user;
+#ifdef USE_CACHED_CREDS
+        const char *cname = NULL;
+#else
         gss_OID_set_desc mechOidSet;
+#endif
         gss_OID_set_desc wantMech;
 
         auth_data = malloc(sizeof(struct private_auth_data));
@@ -188,6 +310,29 @@ krb5_negotiate_reply(struct smb2_context *smb2, const char *server,
                 return NULL;
         }
 
+#ifdef USE_CACHED_CREDS
+        maj = krb5_create_creds_cache(smb2, user_name, smb2->password);
+        if (maj != 0)
+          return NULL;
+
+        cname = krb5_cc_get_name(krb5_cctx, krb5_Ccache);
+        if (cname == NULL)
+        {
+          smb2_set_error(smb2, "Failed to retrieve the credentials cache name");
+          return NULL;
+        }
+        maj = gss_krb5_ccache_name(&min, cname, NULL);
+        if (maj != GSS_S_COMPLETE) {
+                krb5_set_gss_error(smb2, "gss_acquire_cred", maj, min);
+                return NULL;
+        }
+
+        maj = gss_krb5_import_cred(&min, krb5_Ccache, client_princ, 0, &auth_data->cred);
+        if (maj != GSS_S_COMPLETE) {
+                krb5_set_gss_error(smb2, "gss_acquire_cred", maj, min);
+                return NULL;
+        }
+#else
         /* Create creds for the user */
         mechOidSet.count = 1;
         mechOidSet.elements = discard_const(&gss_mech_spnego);
@@ -199,6 +344,7 @@ krb5_negotiate_reply(struct smb2_context *smb2, const char *server,
                 krb5_set_gss_error(smb2, "gss_acquire_cred", maj, min);
                 return NULL;
         }
+#endif
 
         if (smb2->sec != SMB2_SEC_UNDEFINED) {
                 wantMech.count = 1;

--- a/lib/krb5-wrapper.c
+++ b/lib/krb5-wrapper.c
@@ -194,7 +194,7 @@ krb5_create_creds_cache(struct smb2_context *smb2, const char *user, const char 
 
     len = strlen(smb2->domain);
     ret = krb5_build_principal(krb5_cctx, &client_princ, len, smb2->domain, user, NULL);
-    //ret = krb5_parse_name(krb5_cctx, user, &client_princ);
+    /* ret = krb5_parse_name(krb5_cctx, user, &client_princ); */
     if (ret)
     {
       smb2_set_error(smb2, "Failed to get the client principal - %s", krb5_get_error_message(krb5_cctx, ret));
@@ -241,7 +241,7 @@ krb5_create_creds_cache(struct smb2_context *smb2, const char *user, const char 
 int
 krb5_remove_creds_cache(struct private_auth_data *auth_data)
 {
-    //gss_release_cred(NULL, &auth_data->cred);
+    /* gss_release_cred(NULL, &auth_data->cred); */
 
     if (client_princ != NULL)
       krb5_free_principal(krb5_cctx, client_princ);
@@ -252,7 +252,7 @@ krb5_remove_creds_cache(struct private_auth_data *auth_data)
     return 0;
 }
 
-// Enable thhis flag to use krb5 cached creds or else you need to do a kinit
+/* Enable thhis flag to use krb5 cached creds or else you need to do a kinit */
 #define USE_CACHED_CREDS
 
 struct private_auth_data *


### PR DESCRIPTION
Use krb5 credential cache to get and store the TGT and the creds. So instead of calling gss_acquire_cred we can use gss_krb5_import_cred which will use
the cached creds for the user. We use here an IN-MEMORY cache.

This will help user avoid the kinit command before using this library. and also no need of adding details in krb5.conf.