### PR TITLE
Drop using the naked krb5 APIs to manage the krb5 creds cache.

### DIFF
--- a/README
+++ b/README
@@ -53,6 +53,9 @@ Aruments supported by libsmb2 are :
 		  2.02, 2.10, 3.00, 3.02 : negotiate a specific version.
 		  Default is to negotiate any SMB2 or SMB3 version.
 
+NOTE:-
+	When using krb5cc mode use smb2_set_domain() and smb2_set_password() in the examples and applications
+
 Authentication
 ==============
 Libsmb2 provides two different modes of doing authentication. This needs

--- a/lib/init.c
+++ b/lib/init.c
@@ -254,6 +254,14 @@ void smb2_destroy_context(struct smb2_context *smb2)
         free(discard_const(smb2->user));
         free(discard_const(smb2->server));
         free(discard_const(smb2->share));
+
+        if (smb2->domain) {
+            free(discard_const(smb2->domain));
+        }
+        if (smb2->workstation) {
+            free(discard_const(smb2->workstation));
+        }
+
         free(smb2);
 }
 

--- a/lib/krb5-wrapper.h
+++ b/lib/krb5-wrapper.h
@@ -67,8 +67,11 @@ int
 krb5_get_output_token_length(struct private_auth_data *auth_data);
 
 struct private_auth_data *
-krb5_negotiate_reply(struct smb2_context *smb2, const char *server,
-                     const char *user_name);
+krb5_negotiate_reply(struct smb2_context *smb2,
+                     const char *server,
+                     const char *domain,
+                     const char *user_name,
+                     const char *password);
 
 int
 krb5_session_request(struct smb2_context *smb2,

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -576,12 +576,15 @@ negotiate_cb(struct smb2_context *smb2, int status,
 #ifndef HAVE_LIBKRB5
         c_data->auth_data = ntlmssp_init_context(smb2->user,
                                                  smb2->password,
-                                                 smb2->domain, 
+                                                 smb2->domain,
                                                  smb2->workstation,
                                                  smb2->client_challenge);
 #else
-        c_data->auth_data = krb5_negotiate_reply(smb2, c_data->server,
-                                                 c_data->user);
+        c_data->auth_data = krb5_negotiate_reply(smb2,
+                                                 c_data->server,
+                                                 smb2->domain,
+                                                 c_data->user,
+                                                 smb2->password);
 #endif
         if (c_data->auth_data == NULL) {
                 c_data->cb(smb2, -ENOMEM, NULL, c_data->cb_data);


### PR DESCRIPTION
Instead use gss_acquire_cred_with_password() to create a temporary gss creds cache
and use it.

GSSAPI uses the default creds cache. Re-direct the cache to MEMORY
using krb5 APIs so that the TGT and creds will be destroyed once the
current session is complete.