### PR TITLE
use EBADF instead of EBADFD, missing on darwin

### DIFF
--- a/include/msvc/sys/socket.h
+++ b/include/msvc/sys/socket.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include <libsmb2.h>
 
-#define EBADFD WSAENOTSOCK
+#define EBADF WSAENOTSOCK
 
 typedef SSIZE_T ssize_t;
 

--- a/lib/errors.c
+++ b/lib/errors.c
@@ -60,7 +60,7 @@ int nterror_to_errno(uint32_t status) {
         case SMB2_STATUS_OBJECT_NAME_NOT_FOUND:
                 return ENOENT;
         case SMB2_STATUS_FILE_CLOSED:
-                return EBADFD;
+                return EBADF;
         case SMB2_STATUS_MORE_PROCESSING_REQUIRED:
                 return EAGAIN;
         case SMB2_STATUS_ACCESS_DENIED:

--- a/lib/libsmb2.syms
+++ b/lib/libsmb2.syms
@@ -66,6 +66,7 @@ smb2_stat_async
 smb2_telldir
 smb2_truncate
 smb2_truncate_async
+smb2_rename_async
 smb2_unlink
 smb2_unlink_async
 smb2_which_events


### PR DESCRIPTION
Replace EBADFD with EBADF Using EBADF is more portable and correct because EBADFD means a file descriptor in bad state, not an invalid file descriptor.

see https://mail.gnome.org/archives/commits-list/2015-December/msg01323.html