### PR TITLE
Retrieve the SSPI session key after a successful SMB2 SessionSetup

### DIFF
--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -131,12 +131,14 @@ struct smb2_context {
         void *connect_data;
 
         int credits;
-        
+
         char client_guid[16];
-        
+
         uint32_t tree_id;
         uint64_t message_id;
         uint64_t session_id;
+        uint8_t *session_key;
+        uint8_t session_key_size;
 
         /*
          * For sending PDUs

--- a/lib/init.c
+++ b/lib/init.c
@@ -218,7 +218,9 @@ struct smb2_context *smb2_init_context(void)
         }
 
         snprintf(smb2->client_guid, 16, "libsmb2-%d", getpid());
-        
+
+        smb2->session_key = NULL;
+
         return smb2;
 }
 
@@ -249,6 +251,11 @@ void smb2_destroy_context(struct smb2_context *smb2)
         if (smb2->pdu) {
                 smb2_free_pdu(smb2, smb2->pdu);
                 smb2->pdu = NULL;
+        }
+
+        if (smb2->session_key != NULL)
+        {
+          free(smb2->session_key); smb2->session_key = NULL;
         }
 
         free(discard_const(smb2->user));

--- a/lib/krb5-wrapper.h
+++ b/lib/krb5-wrapper.h
@@ -74,6 +74,10 @@ krb5_negotiate_reply(struct smb2_context *smb2,
                      const char *password);
 
 int
+krb5_session_get_session_key(struct smb2_context *smb2,
+                             struct private_auth_data *auth_data);
+
+int
 krb5_session_request(struct smb2_context *smb2,
                      struct private_auth_data *auth_data,
                      unsigned char *buf, int len);

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -486,6 +486,22 @@ session_setup_cb(struct smb2_context *smb2, int status,
                 }
                 return;
         }
+#ifdef HAVE_LIBKRB5
+        else
+        {
+                /* For NTLM the status will be SMB2_STATUS_MORE_PROCESSING_REQUIRED
+                 * and a second call to gss_init_sec_context will complete the gss session.
+                 * But for krb5 a second call to gss_init_sec_context is required if GSS_C_MUTUAL_FLAG is set
+                 */
+                if (krb5_session_request(smb2, c_data->auth_data, rep->security_buffer, rep->security_buffer_length) < 0)
+                {
+                        c_data->cb(smb2, -1, NULL, c_data->cb_data);
+                        free_c_data(smb2, c_data);
+                        return;
+                }
+        }
+#endif
+
 
         if (status != SMB2_STATUS_SUCCESS) {
                 smb2_close_context(smb2);
@@ -496,6 +512,12 @@ session_setup_cb(struct smb2_context *smb2, int status,
                 free_c_data(smb2, c_data);
                 return;
         }
+#ifdef HAVE_LIBKRB5
+        if (krb5_session_get_session_key(smb2, c_data->auth_data) < 0)
+        {
+                return;
+        }
+#endif
 
         memset(&req, 0, sizeof(struct smb2_tree_connect_request));
         req.flags       = 0;


### PR DESCRIPTION
This only works in LIBKRB5 mode.

This is a subset of pullrequest #27 