### PR TITLE
SMB3 Signing Support:-

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ AC_HAVE_LIBRARY(crypt,
 		], [])
 
 # check for openssl/hmac.h openssl/cmac.h openssl/evp.h openssl/sha.h
-AC_CHECK_HEADERS([openssl/hmac.h openssl/cmac.h openssl/evp.h openssl/sha.h openssl/opensslv.h],
+AC_CHECK_HEADERS([openssl/hmac.h openssl/evp.h openssl/sha.h openssl/aes.h openssl/opensslv.h],
                   [],
                   [AC_MSG_WARN([cannot find openssl headers. Building without SEAL support.])
 		  AC_DEFINE(HAVE_OPENSSL_LIBS, 0,

--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -27,6 +27,34 @@
 extern "C" {
 #endif
 
+#ifdef __linux__
+#ifndef __KERNEL__
+#include <endian.h>
+#else
+#include <asm/byteorder.h>
+#endif
+#endif
+
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#endif
+
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
+# define R_ENDIAN_LITTLE
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
+# define R_ENDIAN_BIG
+#elif defined(_BYTE_ORDER) && _BYTE_ORDER == _LITTLE_ENDIAN
+# define R_ENDIAN_LITTLE
+#elif defined(_BYTE_ORDER) && _BYTE_ORDER == _BIG_ENDIAN
+# define R_ENDIAN_BIG
+#elif defined(__LITTLE_ENDIAN) && !defined(__BIG_ENDIAN)
+# define R_ENDIAN_LITTLE
+#elif !defined(__LITTLE_ENDIAN) && defined(__BIG_ENDIAN)
+# define R_ENDIAN_BIG
+#endif
+
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
 #ifndef discard_const
 #define discard_const(ptr) ((void *)((intptr_t)(ptr)))
 #endif
@@ -37,7 +65,9 @@ extern "C" {
 
 #define SMB2_SPL_SIZE 4
 #define SMB2_HEADER_SIZE 64
+
 #define SMB2_SIGNATURE_SIZE 16
+#define SMB2_KEY_SIZE 16
 
 #define SMB2_MAX_VECTORS 256
 
@@ -142,6 +172,7 @@ struct smb2_context {
         uint8_t session_key_size;
 
         uint8_t signing_required;
+        uint8_t signing_key[SMB2_KEY_SIZE];
 
         /*
          * For sending PDUs

--- a/lib/init.c
+++ b/lib/init.c
@@ -221,6 +221,7 @@ struct smb2_context *smb2_init_context(void)
 
         smb2->session_key = NULL;
         smb2->signing_required = 0;
+        memset(smb2->signing_key, 0, SMB2_KEY_SIZE);
 
         return smb2;
 }

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -68,11 +68,32 @@
 #include "libsmb2-raw.h"
 #include "libsmb2-private.h"
 
+#include <openssl/hmac.h>
+#include <openssl/evp.h>
+#include <openssl/sha.h>
+#include <openssl/opensslv.h>
+
+#define OPENSSL_VER_101	0x1000109fL
+#define OPENSSL_VER_102	0x10002100L
+
 #ifndef HAVE_LIBKRB5
 #include "ntlmssp.h"
 #else
 #include "krb5-wrapper.h"
 #endif
+
+/* strings used to derive SMB signing and encryption keys */
+static const char SMB2AESCMAC[] = "SMB2AESCMAC";
+static const char SmbSign[] = "SmbSign";
+static const char SMB2APP[] = "SMB2APP";
+static const char SmbRpc[] = "SmbRpc";
+static const char SMB2AESCCM[] = "SMB2AESCCM";
+static const char ServerOut[] = "ServerOut";
+static const char ServerIn[] = "ServerIn ";
+static const char SMBSigningKey[] = "SMBSigningKey";
+static const char SMBAppKey[] = "SMBAppKey";
+static const char SMBS2CCipherKey[] = "SMBS2CCipherKey";
+static const char SMBC2SCipherKey[] = "SMBC2SCipherKey";
 
 #ifndef O_SYNC
 #ifndef O_DSYNC
@@ -136,6 +157,10 @@ smb2_close_context(struct smb2_context *smb2)
         smb2->message_id = 0;
         smb2->session_id = 0;
         smb2->tree_id = 0;
+        memset(smb2->signing_key, 0, SMB2_KEY_SIZE);
+        free(smb2->session_key);
+        smb2->session_key = NULL;
+        smb2->session_key_size = 0;
 }
 
 static int
@@ -465,6 +490,77 @@ tree_connect_cb(struct smb2_context *smb2, int status,
         free_c_data(smb2, c_data);
 }
 
+#if defined(R_ENDIAN_BIG)
+#define HTOB32(x) (x)
+#else
+#define HTOB32(x) \
+        ((((uint32_t)(x) & 0xFF000000) >> 24) | \
+        (((uint32_t)(x) & 0x00FF0000) >>  8) | \
+        (((uint32_t)(x) & 0x0000FF00) <<  8) | \
+         (((uint32_t)(x) & 0x000000FF) << 24))
+#endif
+
+void smb2_derive_key(
+    uint8_t     *derivation_key,
+    uint32_t    derivation_key_len,
+    const char  *label,
+    uint32_t    label_len,
+    const char  *context,
+    uint32_t    context_len,
+    uint8_t     derived_key[SMB2_KEY_SIZE]
+    )
+{
+        static uint32_t counter = HTOB32(1);
+        static uint32_t keylen = HTOB32(SMB2_KEY_SIZE * 8);
+        static uint8_t nul = 0;
+        uint8_t final_hash[256/8] = {0};
+        uint8_t input_key[SMB2_KEY_SIZE] = {0};
+        unsigned int finalHashSize = sizeof(final_hash);
+
+#if (OPENSSL_VERSION_NUMBER <= OPENSSL_VER_102)
+        HMAC_CTX hmac = {0};
+
+        memcpy(input_key, derivation_key, MIN(sizeof(input_key), derivation_key_len));
+        HMAC_CTX_init(&hmac);
+        HMAC_Init_ex(&hmac, input_key, sizeof(input_key), EVP_sha256(), NULL);
+
+        /* i */
+        HMAC_Update(&hmac, (unsigned char*) &counter, sizeof(counter));
+        /* label */
+        HMAC_Update(&hmac, (unsigned char*) label, label_len);
+        /* 0x00 */
+        HMAC_Update(&hmac, &nul, sizeof(nul));
+        /* context */
+        HMAC_Update(&hmac, (unsigned char*) context, context_len);
+        /* L */
+        HMAC_Update(&hmac, (unsigned char*) &keylen, sizeof(keylen));
+
+        HMAC_Final(&hmac, final_hash, &finalHashSize);
+        HMAC_CTX_cleanup(&hmac);
+#else
+        HMAC_CTX *hmac = HMAC_CTX_new();
+
+        HMAC_CTX_reset(hmac);
+        memcpy(input_key, derivation_key, MIN(sizeof(input_key), derivation_key_len));
+        HMAC_Init_ex(hmac, input_key, sizeof(input_key), EVP_sha256(), NULL);
+
+        /* i */
+        HMAC_Update(hmac, (unsigned char*) &counter, sizeof(counter));
+        /* label */
+        HMAC_Update(hmac, (unsigned char*) label, label_len);
+        /* 0x00 */
+        HMAC_Update(hmac, &nul, sizeof(nul));
+        /* context */
+        HMAC_Update(hmac, (unsigned char*) context, context_len);
+        /* L */
+        HMAC_Update(hmac, (unsigned char*) &keylen, sizeof(keylen));
+
+        HMAC_Final(hmac, final_hash, &finalHashSize);
+        HMAC_CTX_free(hmac); hmac= NULL;
+#endif
+        memcpy(derived_key, final_hash, MIN(finalHashSize, SMB2_KEY_SIZE));
+}
+
 static void
 session_setup_cb(struct smb2_context *smb2, int status,
                  void *command_data, void *private_data)
@@ -520,6 +616,30 @@ session_setup_cb(struct smb2_context *smb2, int status,
                                "Key is not available %s",
                                smb2_get_error(smb2));
                 c_data->cb(smb2, -1, NULL, c_data->cb_data);
+                free_c_data(smb2, c_data);
+                return;
+        }
+
+        /* Derive the signing key from session key
+         * This is based on negotiated protocol
+         */
+        if (smb2->dialect == SMB2_VERSION_0202 || smb2->dialect == SMB2_VERSION_0210) {
+                /* For SMB2 session key is the signing key */
+                memcpy(smb2->signing_key,
+                       smb2->session_key,
+                       MIN(smb2->session_key_size, SMB2_KEY_SIZE));
+        } else if (smb2->dialect <= SMB2_VERSION_0302) {
+                smb2_derive_key(smb2->session_key,
+                                smb2->session_key_size,
+                                SMB2AESCMAC,
+                                sizeof(SMB2AESCMAC),
+                                SmbSign,
+                                sizeof(SmbSign),
+                                smb2->signing_key);
+        } else if (smb2->dialect > SMB2_VERSION_0302) {
+                smb2_close_context(smb2);
+                smb2_set_error(smb2, "Signing Required by server. Not yet implemented for SMB3.1");
+                c_data->cb(smb2, -EINVAL, NULL, c_data->cb_data);
                 free_c_data(smb2, c_data);
                 return;
         }
@@ -622,12 +742,6 @@ negotiate_cb(struct smb2_context *smb2, int status,
                 return;
 #endif
                 smb2->signing_required = 1;
-                if (smb2->dialect > SMB2_VERSION_0210) {
-                        smb2_set_error(smb2, "Signing Required by server. Not yet implemented for SMB3");
-                        c_data->cb(smb2, -EINVAL, NULL, c_data->cb_data);
-                        free_c_data(smb2, c_data);
-                        return;
-                }
         }
 
 #ifndef HAVE_LIBKRB5

--- a/lib/smb2-signing.c
+++ b/lib/smb2-signing.c
@@ -56,18 +56,124 @@
 #include "smb2-signing.h"
 
 #include <openssl/hmac.h>
-#include <openssl/cmac.h>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
+#include <openssl/aes.h>
 #include <openssl/opensslv.h>
 
 #define OPENSSL_VER_101	0x1000109fL
 #define OPENSSL_VER_102	0x10002100L
 
-#define MIN(a,b) (((a)<(b))?(a):(b))
+#define AES128_KEY_LEN     16
 
-#define	SIGNING_KEY_SIZE	16
+static
+int aes_cmac_shift_left(uint8_t data[AES128_KEY_LEN])
+{
+    int i = 0;
+    int cin = 0;
+    int cout = 0;
 
+    for (i = AES128_KEY_LEN - 1; i >= 0; i--)
+    {
+        cout = ((int) data[i] & 0x80) >> 7;
+        data[i] = (data[i] << 1) | cin;
+        cin = cout;
+    }
+
+    return cout;
+}
+
+static
+void aes_cmac_xor(
+    uint8_t data[AES128_KEY_LEN],
+    const uint8_t value[AES128_KEY_LEN]
+    )
+{
+    int i = 0;
+
+    for (i = 0; i < AES128_KEY_LEN; i++)
+    {
+        data[i] ^= value[i];
+    }
+}
+
+static
+void aes_cmac_sub_keys(
+    uint8_t key[AES128_KEY_LEN],
+    uint8_t sub_key1[AES128_KEY_LEN],
+    uint8_t sub_key2[AES128_KEY_LEN]
+    )
+{
+    AES_KEY aes_key;
+    static const uint8_t zero[AES128_KEY_LEN] = {0};
+    static const uint8_t rb[AES128_KEY_LEN] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x87};
+
+    AES_set_encrypt_key(key, 128, &aes_key);
+    AES_encrypt(zero, sub_key1, &aes_key);
+
+    if (aes_cmac_shift_left(sub_key1))
+    {
+        aes_cmac_xor(sub_key1, rb);
+    }
+
+    memcpy(sub_key2, sub_key1, AES128_KEY_LEN);
+
+    if (aes_cmac_shift_left(sub_key2))
+    {
+        aes_cmac_xor(sub_key2, rb);
+    }
+}
+
+void smb3_aes_cmac_128(uint8_t key[AES128_KEY_LEN],
+                   uint8_t * msg,
+                   uint64_t msg_len,
+                   uint8_t mac[AES128_KEY_LEN]
+                  )
+{
+    AES_KEY aes_key;
+    uint8_t sub_key1[AES128_KEY_LEN] = {0};
+    uint8_t sub_key2[AES128_KEY_LEN] = {0};
+    uint8_t scratch[AES128_KEY_LEN] = {0};
+    uint64_t n = (msg_len + AES128_KEY_LEN - 1) / AES128_KEY_LEN;
+    uint64_t rem = msg_len % AES128_KEY_LEN;
+    uint64_t i = 0;
+    int is_last_block_complete = n != 0 && rem == 0;
+
+    if (n == 0)
+    {
+        n = 1;
+    }
+
+    aes_cmac_sub_keys(key, sub_key1, sub_key2);
+
+    memset(mac, 0, AES128_KEY_LEN);
+
+    AES_set_encrypt_key(key, 128, &aes_key);
+
+    for (i = 0; i < n - 1; i++)
+    {
+        aes_cmac_xor(mac, &msg[i*AES128_KEY_LEN]);
+        AES_encrypt(mac, scratch, &aes_key);
+        memcpy(mac, scratch, AES128_KEY_LEN);
+    }
+
+    if (is_last_block_complete)
+    {
+        memcpy(scratch, &msg[i*AES128_KEY_LEN], AES128_KEY_LEN);
+        aes_cmac_xor(scratch, sub_key1);
+    }
+    else
+    {
+        memcpy(scratch, &msg[i*AES128_KEY_LEN], rem);
+        scratch[rem] = 0x80;
+        memset(&scratch[rem + 1], 0, AES128_KEY_LEN - (rem + 1));
+        aes_cmac_xor(scratch, sub_key2);
+    }
+
+    aes_cmac_xor(mac, scratch);
+    AES_encrypt(mac, scratch, &aes_key);
+    memcpy(mac, scratch, AES128_KEY_LEN);
+}
 
 int
 smb2_pdu_add_signature(struct smb2_context *smb2,
@@ -76,8 +182,6 @@ smb2_pdu_add_signature(struct smb2_context *smb2,
 {
         struct smb2_header *hdr = NULL;
         uint8_t signature[16];
-        uint8_t key[SIGNING_KEY_SIZE];
-        int key_len = 0;
         struct smb2_iovec *iov = NULL;
 
         if (pdu->out.niov < 2) {
@@ -98,10 +202,6 @@ smb2_pdu_add_signature(struct smb2_context *smb2,
 
         hdr = &pdu->header;
 
-        memset(&key[0], 0, SIGNING_KEY_SIZE);
-        memcpy(key, smb2->session_key, MIN(smb2->session_key_size, SIGNING_KEY_SIZE));
-        key_len = MIN(smb2->session_key_size, SIGNING_KEY_SIZE);
-
         /* Set the flag before calculating signature */
         iov = &pdu->out.iov[0];
         hdr->flags |= SMB2_FLAGS_SIGNED;
@@ -112,9 +212,24 @@ smb2_pdu_add_signature(struct smb2_context *smb2,
          */
 
         if (smb2->dialect > SMB2_VERSION_0210) {
-                /* TODO signing is not implemented for SMB versions higher than 0210 */
-                smb2_set_error(smb2, "Signing is not supported for SMB3");
-                return -1;
+                int i = 0, offset = 0;
+                uint8_t aes_mac[AES_BLOCK_SIZE];
+                /* combine the buffers into one */
+                uint8_t *msg = NULL;
+                msg = (uint8_t *) malloc(4);
+                if (msg == NULL) {
+                }
+
+                for (i=0; i < pdu->out.niov; i++) {
+                        msg = (uint8_t *)realloc(msg, offset + pdu->out.iov[i].len);
+                        if (msg == NULL) {
+                        }
+                        memcpy(msg+offset, pdu->out.iov[i].buf, pdu->out.iov[i].len);
+                        offset += pdu->out.iov[i].len;
+                }
+                smb3_aes_cmac_128(smb2->signing_key, msg, offset, aes_mac);
+                free(msg);
+                memcpy(&signature[0], aes_mac, SMB2_SIGNATURE_SIZE);
         } else {
                 uint8_t sha_digest[SHA256_DIGEST_LENGTH];
                 unsigned int sha_digest_length = SHA256_DIGEST_LENGTH;
@@ -122,7 +237,7 @@ smb2_pdu_add_signature(struct smb2_context *smb2,
 #if (OPENSSL_VERSION_NUMBER <= OPENSSL_VER_102)
                 HMAC_CTX ctx;
                 HMAC_CTX_init(&ctx);
-                HMAC_Init_ex(&ctx, &key[0], key_len, EVP_sha256(), NULL);
+                HMAC_Init_ex(&ctx, &smb2->signing_key[0], SMB2_KEY_SIZE, EVP_sha256(), NULL);
                 for (i=0; i < pdu->out.niov; i++) {
                         HMAC_Update(&ctx, pdu->out.iov[i].buf, pdu->out.iov[i].len);
                 }
@@ -131,7 +246,7 @@ smb2_pdu_add_signature(struct smb2_context *smb2,
 #else
                 HMAC_CTX *ctx = HMAC_CTX_new();
                 HMAC_CTX_reset(ctx);
-                HMAC_Init_ex(ctx, &key[0], key_len, EVP_sha256(), NULL);
+                HMAC_Init_ex(ctx, &smb2->signing_key[0], SMB2_KEY_SIZE, EVP_sha256(), NULL);
                 for (i=0; i < pdu->out.niov; i++) {
                         HMAC_Update(ctx, pdu->out.iov[i].buf, pdu->out.iov[i].len);
                 }


### PR DESCRIPTION
	Derive the SMB3 signing key.
	Formulate the AES CMAC 128 algorithm
	Compute the MAC for SMB3.00 and SMB3.02

This doesn't work for SMB3.1. The key derivation requires
the preauth context to be extracted.

Signed-off-by: SARAT KUMAR BEHERA <beherasaratkumar@gmail.com>