### PR TITLE
SMB3 Signing Support:-

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ AC_HAVE_LIBRARY(crypt,
 		], [])
 
 # check for openssl/hmac.h openssl/cmac.h openssl/evp.h openssl/sha.h
-AC_CHECK_HEADERS([openssl/hmac.h openssl/cmac.h openssl/evp.h openssl/sha.h openssl/opensslv.h],
+AC_CHECK_HEADERS([openssl/hmac.h openssl/aes.h openssl/evp.h openssl/sha.h openssl/opensslv.h],
                   [],
                   [AC_MSG_WARN([cannot find openssl headers. Building without SEAL support.])
 		  AC_DEFINE(HAVE_OPENSSL_LIBS, 0,

--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -27,6 +27,8 @@
 extern "C" {
 #endif
 
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
 #ifndef discard_const
 #define discard_const(ptr) ((void *)((intptr_t)(ptr)))
 #endif
@@ -37,7 +39,9 @@ extern "C" {
 
 #define SMB2_SPL_SIZE 4
 #define SMB2_HEADER_SIZE 64
+
 #define SMB2_SIGNATURE_SIZE 16
+#define SMB2_KEY_SIZE 16
 
 #define SMB2_MAX_VECTORS 256
 
@@ -142,6 +146,7 @@ struct smb2_context {
         uint8_t session_key_size;
 
         uint8_t signing_required;
+        uint8_t signing_key[SMB2_KEY_SIZE];
 
         /*
          * For sending PDUs

--- a/lib/init.c
+++ b/lib/init.c
@@ -221,6 +221,7 @@ struct smb2_context *smb2_init_context(void)
 
         smb2->session_key = NULL;
         smb2->signing_required = 0;
+        memset(smb2->signing_key, 0, SMB2_KEY_SIZE);
 
         return smb2;
 }


### PR DESCRIPTION
	Derive the SMB3 signing key.
	Formulate the AES CMAC 128 algorithm
	Compute the MAC for SMB3.00 and SMB3.02

This doesn't work for SMB3.1. The key derivation requires
the preauth context to be extracted.

Signed-off-by: SARAT KUMAR BEHERA <beherasaratkumar@gmail.com>