### PR TITLE
Signing support for the built-in NTLMSSP mode

### DIFF
--- a/lib/ntlmssp.h
+++ b/lib/ntlmssp.h
@@ -49,6 +49,8 @@ ntlmssp_generate_blob(struct auth_data *auth_data,
 void
 ntlmssp_destroy_context(struct auth_data *auth);
 
+int ntlmssp_get_session_key(struct auth_data *auth, uint8_t **key, uint8_t *key_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -340,7 +340,7 @@ smb2_queue_pdu(struct smb2_context *smb2, struct smb2_pdu *pdu)
         /* Update all the PDU headers in this chain */
         for (p = pdu; p; p = p->next_compound) {
                 smb2_encode_header(smb2, &p->out.iov[0], &p->header);
-#if defined(HAVE_OPENSSL_LIBS) && defined(HAVE_LIBKRB5)
+#if defined(HAVE_OPENSSL_LIBS)
                 if (smb2->signing_required) {
                         if (smb2_pdu_add_signature(smb2, p) < 0) {
                                 smb2_set_error(smb2, "Failure to add "


### PR DESCRIPTION
For NTLMv2 the session key is to be calculated by the client from
the session base key, which inturn gets generated from the key exchange key.
Since in current implementation we are not doing
key exchange, the key_exchange key is both the session base key
and it is the session key.

Follow - https://blogs.msdn.microsoft.com/openspecification/2010/04/19/ntlm-keys-and-sundry-stuff/
for more details on NTLM keys

Signed-off-by: SARAT KUMAR BEHERA <beherasaratkumar@gmail.com>