### PR TITLE
Fixed import issue in Xcode

### DIFF
--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -19,6 +19,10 @@
 #ifndef _LIBSMB2_H_
 #define _LIBSMB2_H_
 
+#ifndef UINT64_MAX
+#include <stdint.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
`stdint.h` won't import implicitly in Xcode (Apple)