### PR TITLE
Added symbolic link type

### DIFF
--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -45,6 +45,7 @@ typedef void (*smb2_command_cb)(struct smb2_context *smb2, int status,
 /* Stat structure */
 #define SMB2_TYPE_FILE      0x00000000
 #define SMB2_TYPE_DIRECTORY 0x00000001
+#define SMB2_TYPE_SYMLINK   0x00000002
 struct smb2_stat_64 {
         uint32_t smb2_type;
         uint32_t smb2_nlink;

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -270,6 +270,9 @@ decode_dirents(struct smb2_context *smb2, struct smb2dir *dir,
                 if (fs.file_attributes & SMB2_FILE_ATTRIBUTE_DIRECTORY) {
                         ent->dirent.st.smb2_type = SMB2_TYPE_DIRECTORY;
                 }
+                if (fs.file_attributes & SMB2_FILE_ATTRIBUTE_REPARSE_POINT) {
+                        ent->dirent.st.smb2_type = SMB2_TYPE_SYMLINK;
+                }
                 ent->dirent.st.smb2_nlink = 0;
                 ent->dirent.st.smb2_ino = fs.file_id;
                 ent->dirent.st.smb2_size = fs.end_of_file;

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -1464,6 +1464,9 @@ fstat_cb_1(struct smb2_context *smb2, int status,
         if (fs->basic.file_attributes & SMB2_FILE_ATTRIBUTE_DIRECTORY) {
                 st->smb2_type = SMB2_TYPE_DIRECTORY;
         }
+        if (fs->basic.file_attributes & SMB2_FILE_ATTRIBUTE_REPARSE_POINT) {
+                st->smb2_type = SMB2_TYPE_SYMLINK;
+        }
         st->smb2_nlink      = fs->standard.number_of_links;
         st->smb2_ino        = fs->index_number;
         st->smb2_size       = fs->standard.end_of_file;
@@ -1559,6 +1562,9 @@ getinfo_cb_2(struct smb2_context *smb2, int status,
                 st->smb2_type = SMB2_TYPE_FILE;
                 if (fs->basic.file_attributes & SMB2_FILE_ATTRIBUTE_DIRECTORY) {
                         st->smb2_type = SMB2_TYPE_DIRECTORY;
+                }
+                if (fs->basic.file_attributes & SMB2_FILE_ATTRIBUTE_REPARSE_POINT) {
+                        st->smb2_type = SMB2_TYPE_SYMLINK;
                 }
                 st->smb2_nlink      = fs->standard.number_of_links;
                 st->smb2_ino        = fs->index_number;


### PR DESCRIPTION
Interprets reparse points as symbolic links.

Considering a reparse point can't be passed to `smb2_unlink()`, `smb2_rename()`, etc methods, we should declare it as a separate type.

While reparse points can be different types than symlinks ([see here](https://en.wikipedia.org/wiki/NTFS_reparse_point#Features)) but I think the most common type are symbolic links. Regardless, the APIs for managing all of them are same.

We will implement functions regarding symbolic link later using ioctl interface.