### PR TITLE
fix memcpy fileid

### DIFF
--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -2127,7 +2127,7 @@ smb2_fh_from_file_id(smb2_file_id *fileid)
                 return NULL;
         }
         memset(fh, 0, sizeof(struct smb2fh));
-        memcpy(fh->file_id, file_id, SMB2_FD_SIZE);
+        memcpy(fh->file_id, fileid, SMB2_FD_SIZE);
 
         return fh;
 }


### PR DESCRIPTION
Now it is also possible to compile the project again.
Reference:
```bash
BUILDSTDERR: /builddir/build/BUILD/libsmb2-7075898d28035e4475a41ab135f45e98394f0e37/lib/libsmb2.c: In function 'smb2_fh_from_file_id':
BUILDSTDERR: /builddir/build/BUILD/libsmb2-7075898d28035e4475a41ab135f45e98394f0e37/lib/libsmb2.c:2130:29: error: 'file_id' undeclared (first use in this function); did you mean 'fileid'?
BUILDSTDERR:          memcpy(fh->file_id, file_id, SMB2_FD_SIZE);
BUILDSTDERR:                              ^~~~~~~
BUILDSTDERR:                              fileid
BUILDSTDERR: /builddir/build/BUILD/libsmb2-7075898d28035e4475a41ab135f45e98394f0e37/lib/libsmb2.c:2130:29: note: each undeclared identifier is reported only once for each function it appears in
BUILDSTDERR: make[2]: *** [lib/CMakeFiles/smb2.dir/build.make:183: lib/CMakeFiles/smb2.dir/libsmb2.c.o] Error 1
```