### PR TITLE
cmake LIB_SUFFIX patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ project(libsmb2
 
 set(SOVERSION 1 CACHE STRING "" FORCE)
 
-set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
+set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "Installation directory for libraries")
 set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
-set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
-set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake/libsmb2" CACHE PATH "Installation directory for cmake (.cmake) files")
+set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/cmake/libsmb2" CACHE PATH "Installation directory for cmake (.cmake) files")
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(ENABLE_EXAMPLES "Build example programs" OFF)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -58,5 +58,5 @@ endif()
 
 install(TARGETS smb2 EXPORT smb2
                      RUNTIME DESTINATION bin
-                     ARCHIVE DESTINATION lib
-                     LIBRARY DESTINATION lib)
+                     ARCHIVE DESTINATION lib${LIB_SUFFIX}
+                     LIBRARY DESTINATION lib${LIB_SUFFIX})


### PR DESCRIPTION
enables lib / lib64 cmake builds. (by default)
EDIT: tested under linux only.