### PR TITLE
smb2_destroy_context: fix possible null-deref

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -245,14 +245,6 @@ void smb2_destroy_context(struct smb2_context *smb2)
                 smb2->fd = -1;
         }
 
-        if (smb2->fhs) {
-                smb2_free_all_fhs(smb2);
-        }
-
-        if (smb2->dirs) {
-                smb2_free_all_dirs(smb2);
-        }
-
         while (smb2->outqueue) {
                 struct smb2_pdu *pdu = smb2->outqueue;
 
@@ -271,6 +263,14 @@ void smb2_destroy_context(struct smb2_context *smb2)
         if (smb2->pdu) {
                 smb2_free_pdu(smb2, smb2->pdu);
                 smb2->pdu = NULL;
+        }
+
+        if (smb2->fhs) {
+                smb2_free_all_fhs(smb2);
+        }
+
+        if (smb2->dirs) {
+                smb2_free_all_dirs(smb2);
         }
 
         free(smb2->session_key);


### PR DESCRIPTION
This fix the following null-deref in VLC:

```
Thread 25 "vlc" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffbc479700 (LWP 31258)]
0x00007fffbc6d195c in free_smb2fh (smb2=0x7fffa8002390, fh=0x7fffa8036960) at libsmb2.c:893
893	        SMB2_LIST_REMOVE(&smb2->fhs, fh);
(gdb) bt
#0  0x00007fffbc6d195c in free_smb2fh (smb2=0x7fffa8002390, fh=0x7fffa8036960) at libsmb2.c:893
#1  0x00007fffbc6d1d9a in close_cb (smb2=0x7fffa8002390, status=-1, command_data=0x0, private_data=0x7fffa8036960)
    at libsmb2.c:1015
#2  0x00007fffbc6cf618 in smb2_destroy_context (smb2=0x7fffa8002390) at init.c:260
#3  0x00007fffbc6cdec4 in Close (p_obj=0x7fffa8000be0) at ../../modules/access/smb2.c:731
#4  0x00007ffff7ec28d6 in module_unneed (obj=obj@entry=0x7fffa8000be0, module=0x5555555b8fd0)
    at ../../src/modules/modules.c:274
#5  0x00007ffff7ed5874 in vlc_access_Destroy (access=0x7fffa8000be0) at ../../src/input/access.c:70
#6  0x00007ffff7f0205a in vlc_stream_Delete (s=0x7fffa8000be0) at ../../src/input/stream.c:137
#7  0x00007ffff7f0205a in vlc_stream_Delete (s=0x7fffa8030ff0) at ../../src/input/stream.c:137
#8  0x00007ffff7f0407d in StreamDelete (s=0x7fffa8026e70) at ../../src/input/stream_filter.c:46
#9  0x00007ffff7f0205a in vlc_stream_Delete (s=0x7fffa8026e70) at ../../src/input/stream.c:137
#10 0x00007ffff7f0407d in StreamDelete (s=0x7fffa8031950) at ../../src/input/stream_filter.c:46
#11 0x00007ffff7f0205a in vlc_stream_Delete (s=0x7fffa8031950) at ../../src/input/stream.c:137
#12 0x00007ffff7eecea5 in InputDemuxNew
    (psz_anchor=0x7ffff7f645e6 "", psz_demux=0x7fffa807d910 "any", url=<optimized out>, p_source=0x7fffa80472c0, p_input=0x7fffd8001c70) at ../../src/input/input.c:2453
#13 0x00007ffff7eecea5 in InputSourceNew
    (p_input=<optimized out>, psz_mrl=<optimized out>, psz_forced_demux=<optimized out>, b_in_can_fail=<optimized out>) at ../../src/input/input.c:2555
#14 0x00007ffff7eefd8c in Init (p_input=0x7fffd8001c70) at ../../src/input/input.c:1261
#15 0x00007ffff7ef307c in Run (data=0x7fffd8001c70) at ../../src/input/input.c:456
#16 0x00007ffff7a30fa3 in start_thread (arg=<optimized out>) at pthread_create.c:486
#17 0x00007ffff79614cf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

It happened when a VLC's input was closed by the user (interrupted): smb2_close_async() was not processed with smb2_service().

There is also a fix for VLC, cf. https://mailman.videolan.org/pipermail/vlc-devel/2019-August/126777.html
With this fix, the smb2 module will try to close the smb2 nicely, even in case of interruption by the user. But there is still a possibility for this crash to happen in case of network connection issues.
