### PR TITLE
Android: fix getlogin_r() dep

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -65,6 +65,14 @@
 #define getlogin_r(a,b) ENXIO
 #endif
 
+#ifdef __ANDROID__
+#include <errno.h>
+// getlogin_r() was added in API 28
+#if __ANDROID_API__ < 28
+#define getlogin_r(a,b) ENXIO
+#endif
+#endif // __ANDROID__
+
 static int
 smb2_parse_args(struct smb2_context *smb2, const char *args)
 {

--- a/lib/init.c
+++ b/lib/init.c
@@ -52,15 +52,17 @@
 #define MAX_URL_SIZE 256
 
 #ifdef _MSC_VER
-#define getlogin_r() ENXIO
+#include <errno.h>
+#define getlogin_r(a,b) ENXIO
 #define random rand
 #define getpid GetCurrentProcessId
 #endif // _MSC_VER
 
 #ifdef ESP_PLATFORM
+#include <errno.h>
 #include <esp_system.h>
 #define random esp_random
-#define getlogin_r() ENXIO
+#define getlogin_r(a,b) ENXIO
 #endif
 
 static int


### PR DESCRIPTION
* The getlogin_r() fallback was not working and not tested.
* It is also needed for Android before API 28

For Android, we could also fallback to getlogin() but I prefer returning an error here instead of using an unsafe function. Your call.