### PR TITLE
Don't override password set via smb2_set_password()

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -386,8 +386,6 @@ static void smb2_set_password_from_file(struct smb2_context *smb2)
         char *domain, *user, *password;
         int finished;
 
-        smb2_set_password(smb2, NULL);
-
 #ifdef _MSC_UWP
 // GetEnvironmentVariable is not available for UWP up to 10.0.16299 SDK
 #if defined(NTDDI_WIN10_RS3) && (NTDDI_VERSION >= NTDDI_WIN10_RS3)
@@ -413,6 +411,9 @@ static void smb2_set_password_from_file(struct smb2_context *smb2)
         if (!fh) {
             return;
         }
+
+        smb2_set_password(smb2, NULL);
+
         while (!feof(fh)) {
                 if (fgets(buf, 256, fh) == NULL) {
                         break;

--- a/lib/init.c
+++ b/lib/init.c
@@ -410,6 +410,9 @@ static void smb2_set_password_from_file(struct smb2_context *smb2)
 #ifdef _MSC_UWP
         free(name);
 #endif
+        if (!fh) {
+            return;
+        }
         while (!feof(fh)) {
                 if (fgets(buf, 256, fh) == NULL) {
                         break;


### PR DESCRIPTION
Regression from bf5c12d

This was impossible for an user to provide a password via smb2_set_password()
since it was overridden from smb2_connect_share_async(). Indeed,
smb2_set_password_from_file() is called from smb2_set_user(), that is called
from smb2_connect_share_async().