### PR TITLE
Remove unused popt dependency for examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_library(POPT_LIBRARY popt)
-
 list(APPEND CORE_LIBRARIES ${POPT_LIBRARY})
 
 set(SOURCES smb2-cat-async

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -18,7 +18,7 @@ AM_CPPFLAGS = \
 	"-D_U_=__attribute__((unused))" \
 	-Wall -Werror
 
-COMMON_LIBS = ../lib/libsmb2.la -lpopt
+COMMON_LIBS = ../lib/libsmb2.la
 smb2_cat_async_LDADD = $(COMMON_LIBS)
 smb2_cat_sync_LDADD = $(COMMON_LIBS)
 smb2_ftruncate_sync_LDADD = $(COMMON_LIBS)


### PR DESCRIPTION
The examples have a dependency on popt even though that library is
not used by any examples, making it unnecessary.