### PR TITLE
aes128ccm: Add missing portable-endian header

### DIFF
--- a/lib/aes128ccm.c
+++ b/lib/aes128ccm.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "portable-endian.h"
 #include "aes.h"
 
 static void aes_ccm_generate_b0(unsigned char *nonce, int nlen,


### PR DESCRIPTION
This fixes the compilation on macOS and other platforms that
do not have `htobe*` functions.