### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,24 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build-linux:
+    name: Linux build
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y libkrb5-dev
+    - name: configure
+      run: |
+        ./bootstrap
+        ./configure
+    - name: make
+      run: make
+    - name: make distcheck
+      run: make distcheck


### PR DESCRIPTION
This adds GItHub CI support to test compilation of the library.
Currently only the autotools build is tested.
Distcheck fails for now (see #107).