### PR TITLE
More errnos

### DIFF
--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -192,7 +192,7 @@ const char *smb2_get_client_guid(struct smb2_context *smb2);
  * status can be either of :
  *    0     : Connection was successful. Command_data is NULL.
  *
- *   <0     : Failed to establish the connection. Command_data is NULL.
+ *   -errno : Failed to establish the connection. Command_data is NULL.
  */
 int smb2_connect_async(struct smb2_context *smb2, const char *server,
                        smb2_command_cb cb, void *cb_data);

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -888,6 +888,7 @@ smb2_connect_share_async(struct smb2_context *smb2,
                          smb2_command_cb cb, void *cb_data)
 {
         struct connect_data *c_data;
+        int err;
 
         if (smb2->server) {
                 free(discard_const(smb2->server));
@@ -950,9 +951,10 @@ smb2_connect_share_async(struct smb2_context *smb2,
         c_data->cb = cb;
         c_data->cb_data = cb_data;
 
-        if (smb2_connect_async(smb2, server, connect_cb, c_data) != 0) {
+        err = smb2_connect_async(smb2, server, connect_cb, c_data);
+        if (err != 0) {
                 free_c_data(smb2, c_data);
-                return -ENOMEM;
+                return err;
         }
 
         return 0;

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -667,14 +667,14 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
         if (smb2->fd != -1) {
                 smb2_set_error(smb2, "Trying to connect but already "
                                "connected.");
-                return -1;
+                return -EINVAL;
         }
 
         addr = strdup(server);
         if (addr == NULL) {
                 smb2_set_error(smb2, "Out-of-memory: "
                                "Failed to strdup server address.");
-                return -1;
+                return -ENOMEM;
         }
         host = addr;
         port = host;
@@ -689,7 +689,7 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
                         free(addr);
                         smb2_set_error(smb2, "Invalid address:%s  "
                                 "Missing ']' in IPv6 address", server);
-                        return -1;
+                        return -EINVAL;
                 }
                 *str = 0;
                 port = str + 1;
@@ -707,7 +707,7 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
                 free(addr);
                 smb2_set_error(smb2, "Invalid address:%s  "
                                "Can not resolv into IPv4/v6.", server);
-                return -1;
+                return -EINVAL;
         }
         free(addr);
 
@@ -734,7 +734,7 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
                                 "Only IPv4/IPv6 supported so far.",
                                 ai->ai_family);
                 freeaddrinfo(ai);
-                return -1;
+                return -EINVAL;
 
         }
         family = ai->ai_family;
@@ -748,7 +748,7 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
 	if (smb2->fd == -1) {
 		smb2_set_error(smb2, "Failed to open smb2 socket. "
                                "Errno:%s(%d).", strerror(errno), errno);
-		return -1;
+		return -EIO;
 	}
 
 	set_nonblocking(smb2->fd);
@@ -764,7 +764,7 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
 			"%s(%d)", strerror(errno), errno);
 		close(smb2->fd);
 		smb2->fd = -1;
-		return -1;
+		return -EIO;
 	}
 
         return 0;


### PR DESCRIPTION
This PR fixes invalid errno returned by smb2_connect_share_async() and add errnos to smb2_connect_async() return values.

FYI: smb2_connect_share_async() was returning -ENOMEM in case of I/O errors.

This will be used by VLC to know the reason of a connect failure and setup fallback SMBv1 fallback accordingly.