### PR TITLE
evaluate smb status before call to krb5 lib

### DIFF
--- a/README
+++ b/README
@@ -133,8 +133,8 @@ by calling :
 
 SMB2/3 SIGNING
 ==============
-Signing is only supported with KRB5 or with the builtin ntlmssp support.
-Signing is not supported when the gss-ntlmssp mech plugin is used.
+Signing is supported with KRB5, with the builtin ntlmssp support and with
+gss-ntlmssp mech plugin.
 
 SMB3 Encryption
 ===============


### PR DESCRIPTION
This leads to better error messages. For example, for incorrect pass we
have a message like following:
Session setup failed with (0xc000006d) STATUS_LOGON_FAILURE (-111)
with current change instead of
gss_init_sec_context: (Invalid token was supplied, Unknown error) (-1)