### PR TITLE
add const qualifier for smb write related code

### DIFF
--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -529,9 +529,9 @@ int smb2_pread(struct smb2_context *smb2, struct smb2fh *fh,
  * -errno : An error occured.
  *
  * Command_data is always NULL.
- */       
+ */
 int smb2_pwrite_async(struct smb2_context *smb2, struct smb2fh *fh,
-                      uint8_t *buf, uint32_t count, uint64_t offset,
+                      const uint8_t *buf, uint32_t count, uint64_t offset,
                       smb2_command_cb cb, void *cb_data);
 
 /*
@@ -540,7 +540,7 @@ int smb2_pwrite_async(struct smb2_context *smb2, struct smb2fh *fh,
  * server supports.
  */
 int smb2_pwrite(struct smb2_context *smb2, struct smb2fh *fh,
-                uint8_t *buf, uint32_t count, uint64_t offset);
+                const uint8_t *buf, uint32_t count, uint64_t offset);
 
 /*
  * READ
@@ -587,14 +587,14 @@ int smb2_read(struct smb2_context *smb2, struct smb2fh *fh,
  * Command_data is always NULL.
  */
 int smb2_write_async(struct smb2_context *smb2, struct smb2fh *fh,
-                     uint8_t *buf, uint32_t count,
+                     const uint8_t *buf, uint32_t count,
                      smb2_command_cb cb, void *cb_data);
 
 /*
  * Sync write()
  */
 int smb2_write(struct smb2_context *smb2, struct smb2fh *fh,
-               uint8_t *buf, uint32_t count);
+               const uint8_t *buf, uint32_t count);
 
 /*
  * Sync lseek()

--- a/include/smb2/smb2.h
+++ b/include/smb2/smb2.h
@@ -837,7 +837,7 @@ struct smb2_ioctl_reply {
 struct smb2_write_request {
         uint32_t length;
         uint64_t offset;
-        uint8_t *buf;
+        const uint8_t* buf;
         smb2_file_id file_id;
         uint32_t channel;
         uint32_t remaining_bytes;

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -1273,7 +1273,7 @@ write_cb(struct smb2_context *smb2, int status,
 
 int
 smb2_pwrite_async(struct smb2_context *smb2, struct smb2fh *fh,
-                  uint8_t *buf, uint32_t count, uint64_t offset,
+                  const uint8_t *buf, uint32_t count, uint64_t offset,
                   smb2_command_cb cb, void *cb_data)
 {
         struct smb2_write_request req;
@@ -1330,7 +1330,7 @@ smb2_pwrite_async(struct smb2_context *smb2, struct smb2fh *fh,
 
 int
 smb2_write_async(struct smb2_context *smb2, struct smb2fh *fh,
-                 uint8_t *buf, uint32_t count,
+                 const uint8_t *buf, uint32_t count,
                  smb2_command_cb cb, void *cb_data)
 {
         return smb2_pwrite_async(smb2, fh, buf, count, fh->offset,

--- a/lib/smb2-cmd-write.c
+++ b/lib/smb2-cmd-write.c
@@ -102,7 +102,7 @@ smb2_cmd_write_async(struct smb2_context *smb2,
                 return NULL;
         }
 
-        smb2_add_iovector(smb2, &pdu->out, req->buf,
+        smb2_add_iovector(smb2, &pdu->out, (uint8_t*)req->buf,
                           req->length, NULL);
         
         if (smb2_pad_to_64bit(smb2, &pdu->out) != 0) {

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -290,7 +290,7 @@ int smb2_pread(struct smb2_context *smb2, struct smb2fh *fh,
 }
 
 int smb2_pwrite(struct smb2_context *smb2, struct smb2fh *fh,
-                uint8_t *buf, uint32_t count, uint64_t offset)
+                const uint8_t *buf, uint32_t count, uint64_t offset)
 {
         struct sync_cb_data cb_data;
 
@@ -330,7 +330,7 @@ int smb2_read(struct smb2_context *smb2, struct smb2fh *fh,
 }
 
 int smb2_write(struct smb2_context *smb2, struct smb2fh *fh,
-               uint8_t *buf, uint32_t count)
+               const uint8_t *buf, uint32_t count)
 {
         struct sync_cb_data cb_data;
 


### PR DESCRIPTION
This helps in making caller code free of casts. Also, at the caller side, in many cases, a guarantee of constantness is needed from the library to avoid copying of buffers.