### PR TITLE
fix __cplusplus guards

### DIFF
--- a/include/smb2/libsmb2-dcerpc-srvsvc.h
+++ b/include/smb2/libsmb2-dcerpc-srvsvc.h
@@ -36,5 +36,8 @@ int srvsvc_netshareenumall_encoder(struct dcerpc_context *ctx,
                                    struct dcerpc_pdu *pdu,
                                    struct smb2_iovec *iov, int offset,
                                    void *ptr);
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_LIBSMB2_DCERPC_SRVSVC_H_ */

--- a/include/smb2/libsmb2-dcerpc.h
+++ b/include/smb2/libsmb2-dcerpc.h
@@ -99,8 +99,8 @@ int dcerpc_process_deferred_pointers(struct dcerpc_context *ctx,
 void dcerpc_add_deferred_pointer(struct dcerpc_context *ctx,
                                  struct dcerpc_pdu *pdu,
                                  dcerpc_coder coder, void *ptr);
-
-
-
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_LIBSMB2_DCERPC_H_ */

--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -864,9 +864,6 @@ int smb2_echo_async(struct smb2_context *smb2,
  */
 int smb2_echo(struct smb2_context *smb2);
 
-#ifdef __cplusplus
-}
-#endif
 
 /* Low 2 bits desctibe the type */
 #define SHARE_TYPE_DISKTREE  0
@@ -929,4 +926,7 @@ struct srvsvc_netshareenumall_rep {
 int smb2_share_enum_async(struct smb2_context *smb2,
                           smb2_command_cb cb, void *cb_data);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* !_LIBSMB2_H_ */


### PR DESCRIPTION
* Some functions weren't included in the __cplusplus scope which caused
the compiler to mangle those names which made it impossible for the
linker to find the proper names.

* Properly close all the __cplusplus scopes. Some of them were left
opened and caused weird errors when compiling c++ code.