### PR TITLE
map smb3 signing error to EACCES

### DIFF
--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -670,7 +670,7 @@ session_setup_cb(struct smb2_context *smb2, int status,
                         smb2_set_error(smb2, "Signing required by server. Session "
                                        "Key is not available %s",
                                        smb2_get_error(smb2));
-                        c_data->cb(smb2, -1, NULL, c_data->cb_data);
+                        c_data->cb(smb2, -EACCES, NULL, c_data->cb_data);
                         free_c_data(smb2, c_data);
                         return;
                 }


### PR DESCRIPTION
To let the lib user know the error is a login issue (and that he could
try again without anonymous).