### PR TITLE
fix build on APPLE

### DIFF
--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -23,7 +23,7 @@
 #include "config.h"
 #endif
 
-#if defined(PS2_EE_PLATFORM) || defined(PS3_PPU_PLATFORM) || defined(ESP_PLATFORM)
+#if defined(PS2_EE_PLATFORM) || defined(PS3_PPU_PLATFORM) || defined(ESP_PLATFORM) || defined(__APPLE__)
 /* We need this for time_t */
 #include <time.h>
 #endif

--- a/include/smb2/libsmb2-dcerpc.h
+++ b/include/smb2/libsmb2-dcerpc.h
@@ -50,22 +50,22 @@ typedef struct dcerpc_uuid {
         uint16_t v2;
         uint16_t v3;
         uint64_t v4;
-} uuid_t;
+} dcerpc_uuid_t;
 
 typedef struct p_syntax_id {
-        uuid_t uuid;
+        dcerpc_uuid_t uuid;
         uint16_t vers;
         uint16_t vers_minor;
 } p_syntax_id_t;
 
 struct ndr_transfer_syntax {
-        uuid_t uuid;
+        dcerpc_uuid_t uuid;
         uint16_t vers;
 };
 
 struct ndr_context_handle {
         uint32_t context_handle_attributes;
-        uuid_t context_handle_uuid;
+        dcerpc_uuid_t context_handle_uuid;
 };
 
 extern p_syntax_id_t lsa_interface;

--- a/lib/dcerpc.c
+++ b/lib/dcerpc.c
@@ -131,7 +131,7 @@ struct dcerpc_bind_pdu {
 struct dcerpc_bind_context_results {
         uint16_t ack_result;
         uint16_t ack_reason;
-        uuid_t uuid;
+        dcerpc_uuid_t uuid;
         uint32_t syntax_version;
 };
 
@@ -153,7 +153,7 @@ struct dcerpc_request_pdu {
 
       /* optional field for request, only present if the PFC_OBJECT_UUID
          * field is non-zero */
-      /*  uuid_t  object;              24:16 object UID */
+      /*  dcerpc_uuid_t  object;              24:16 object UID */
 
       /* stub data, 8-octet aligned 
                    .
@@ -992,7 +992,7 @@ dcerpc_decode_header(struct smb2_iovec *iov, struct dcerpc_header *hdr)
 static int
 dcerpc_encode_uuid(struct dcerpc_context *ctx,
                    struct smb2_iovec *iov, int offset,
-                   uuid_t *uuid)
+                   dcerpc_uuid_t *uuid)
 {
         if (offset < 0) {
                 return offset;
@@ -1028,7 +1028,7 @@ dcerpc_encode_uuid(struct dcerpc_context *ctx,
 static int
 dcerpc_decode_uuid(struct dcerpc_context *ctx,
                    struct smb2_iovec *iov, int offset,
-                   uuid_t *uuid)
+                   dcerpc_uuid_t *uuid)
 {
         uint8_t ch;
         int i;
@@ -1057,7 +1057,7 @@ dcerpc_decode_uuid(struct dcerpc_context *ctx,
 /**********************
  * typedef struct ndr_context_handle {
  *    unsigned32 context_handle_attributes;
- *    uuid_t context_handle_uuid;
+ *    dcerpc_uuid_t context_handle_uuid;
  * } ndr_context_handle;
  **********************/
 static int


### PR DESCRIPTION
uuid_t is reserved by APPLE. It's a bad idea to add "_t" suffixes in
user program.

Apple need also time.h for time_t. Since C11, time_t is defined in
time.h, so not sure if all these ifdef are needed.