### PR TITLE
Fix connection on IPV4-only servers

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -105,14 +105,14 @@ smb2_get_credit_charge(struct smb2_context *smb2, struct smb2_pdu *pdu)
 int
 smb2_which_events(struct smb2_context *smb2)
 {
-	int events = smb2->is_connected ? POLLIN : POLLOUT;
+        int events = smb2->is_connected ? POLLIN : POLLOUT;
 
         if (smb2->outqueue != NULL &&
             smb2_get_credit_charge(smb2, smb2->outqueue) <= smb2->credits) {
                 events |= POLLOUT;
         }
-        
-	return events;
+
+        return events;
 }
 
 t_socket smb2_get_fd(struct smb2_context *smb2)
@@ -124,13 +124,13 @@ static int
 smb2_write_to_socket(struct smb2_context *smb2)
 {
         struct smb2_pdu *pdu;
-        
-	if (smb2->fd == -1) {
-		smb2_set_error(smb2, "trying to write but not connected");
-		return -1;
-	}
 
-	while ((pdu = smb2->outqueue) != NULL) {
+        if (smb2->fd == -1) {
+                smb2_set_error(smb2, "trying to write but not connected");
+                return -1;
+        }
+
+        while ((pdu = smb2->outqueue) != NULL) {
                 struct iovec iov[SMB2_MAX_VECTORS];
                 struct iovec *tmpiov;
                 struct smb2_pdu *tmp_pdu;
@@ -196,7 +196,7 @@ smb2_write_to_socket(struct smb2_context *smb2)
                                        smb2_get_error(smb2));
                         return -1;
                 }
-                
+
                 pdu->out.num_done += count;
 
                 if (pdu->out.num_done == SMB2_SPL_SIZE + spl) {
@@ -217,8 +217,8 @@ smb2_write_to_socket(struct smb2_context *smb2)
                                 pdu = tmp_pdu;
                         }
                 }
-	}
-	return 0;
+        }
+        return 0;
 }
 
 typedef ssize_t (*read_func)(struct smb2_context *smb2,
@@ -232,11 +232,11 @@ int smb2_read_data(struct smb2_context *smb2, read_func func)
         size_t num_done;
         static char smb3tfrm[4] = {0xFD, 'S', 'M', 'B'};
         struct smb2_pdu *pdu = smb2->pdu;
-	ssize_t count, len;
+        ssize_t count, len;
 
 read_more_data:
         num_done = smb2->in.num_done;
-        
+
         /* Copy all the current vectors to our work vector */
         niov = smb2->in.niov;
         for (i = 0; i < niov; i++) {
@@ -244,14 +244,14 @@ read_more_data:
                 iov[i].iov_len = smb2->in.iov[i].len;
         }
         tmpiov = iov;
-        
+
         /* Skip the vectors we have already read */
         while (num_done >= tmpiov->iov_len) {
                 num_done -= tmpiov->iov_len;
                 tmpiov++;
                 niov--;
         }
-        
+
         /* Adjust the first vector to read */
         tmpiov->iov_base = (char *)tmpiov->iov_base + num_done;
         tmpiov->iov_len -= num_done;
@@ -529,9 +529,9 @@ read_more_data:
         /* We are all done now with this chain. Reset num_done to 0
          * and restart with a new SPL for the next chain.
          */
-        smb2->in.num_done = 0;        
+        smb2->in.num_done = 0;
 
-	return 0;
+        return 0;
 }
 
 static ssize_t smb2_readv_from_socket(struct smb2_context *smb2,
@@ -588,79 +588,79 @@ smb2_service(struct smb2_context *smb2, int revents)
 {
         int ret = 0;
 
-	if (smb2->fd < 0) {
+        if (smb2->fd < 0) {
                 goto out;
-	}
+        }
 
         if (revents & POLLERR) {
-		int err = 0;
-		socklen_t err_size = sizeof(err);
+                int err = 0;
+                socklen_t err_size = sizeof(err);
 
-		if (getsockopt(smb2->fd, SOL_SOCKET, SO_ERROR,
-			       (char *)&err, &err_size) != 0 || err != 0) {
-			if (err == 0) {
-				err = errno;
-			}
-			smb2_set_error(smb2, "smb2_service: socket error "
-					"%s(%d).",
-					strerror(err), err);
-		} else {
-			smb2_set_error(smb2, "smb2_service: POLLERR, "
-					"Unknown socket error.");
-		}
-		ret = -1;
-                goto out;
-	}
-	if (revents & POLLHUP) {
-		smb2_set_error(smb2, "smb2_service: POLLHUP, "
-				"socket error.");
+                if (getsockopt(smb2->fd, SOL_SOCKET, SO_ERROR,
+                               (char *)&err, &err_size) != 0 || err != 0) {
+                        if (err == 0) {
+                                err = errno;
+                        }
+                        smb2_set_error(smb2, "smb2_service: socket error "
+                                        "%s(%d).",
+                                        strerror(err), err);
+                } else {
+                        smb2_set_error(smb2, "smb2_service: POLLERR, "
+                                        "Unknown socket error.");
+                }
                 ret = -1;
                 goto out;
-	}
+        }
+        if (revents & POLLHUP) {
+                smb2_set_error(smb2, "smb2_service: POLLHUP, "
+                                "socket error.");
+                ret = -1;
+                goto out;
+        }
 
-	if (smb2->is_connected == 0 && revents & POLLOUT) {
-		int err = 0;
-		socklen_t err_size = sizeof(err);
+        if (smb2->is_connected == 0 && revents & POLLOUT) {
+                int err = 0;
+                socklen_t err_size = sizeof(err);
 
-		if (getsockopt(smb2->fd, SOL_SOCKET, SO_ERROR,
-			       (char *)&err, &err_size) != 0 || err != 0) {
-			if (err == 0) {
-				err = errno;
-			}
-			smb2_set_error(smb2, "smb2_service: socket error "
-					"%s(%d) while connecting.",
-					strerror(err), err);
-			if (smb2->connect_cb) {
-				smb2->connect_cb(smb2, err,
+                if (getsockopt(smb2->fd, SOL_SOCKET, SO_ERROR,
+                               (char *)&err, &err_size) != 0 || err != 0) {
+                        if (err == 0) {
+                                err = errno;
+                        }
+                        smb2_set_error(smb2, "smb2_service: socket error "
+                                        "%s(%d) while connecting.",
+                                        strerror(err), err);
+                        if (smb2->connect_cb) {
+                                smb2->connect_cb(smb2, err,
                                                  NULL, smb2->connect_data);
-				smb2->connect_cb = NULL;
-			}
+                                smb2->connect_cb = NULL;
+                        }
                         ret = -1;
                         goto out;
-		}
+                }
 
-		smb2->is_connected = 1;
+                smb2->is_connected = 1;
                 smb2_change_events(smb2, smb2->fd, smb2_which_events(smb2));
-		if (smb2->connect_cb) {
-			smb2->connect_cb(smb2, 0, NULL,	smb2->connect_data);
-			smb2->connect_cb = NULL;
-		}
-		goto out;
-	}
+                if (smb2->connect_cb) {
+                        smb2->connect_cb(smb2, 0, NULL,        smb2->connect_data);
+                        smb2->connect_cb = NULL;
+                }
+                goto out;
+        }
 
-	if (revents & POLLIN) {
-		if (smb2_read_from_socket(smb2) != 0) {
+        if (revents & POLLIN) {
+                if (smb2_read_from_socket(smb2) != 0) {
                         ret = -1;
                         goto out;
-		}
-	}
-        
-	if (revents & POLLOUT && smb2->outqueue != NULL) {
-		if (smb2_write_to_socket(smb2) != 0) {
+                }
+        }
+
+        if (revents & POLLOUT && smb2->outqueue != NULL) {
+                if (smb2_write_to_socket(smb2) != 0) {
                         ret = -1;
                         goto out;
-		}
-	}
+                }
+        }
 
  out:
         if (smb2->timeout) {
@@ -673,32 +673,32 @@ static void
 set_nonblocking(t_socket fd)
 {
 #if defined(WIN32)
-	unsigned long opt = 1;
-	ioctlsocket(fd, FIONBIO, &opt);
+        unsigned long opt = 1;
+        ioctlsocket(fd, FIONBIO, &opt);
 #else
-	unsigned v;
-	v = fcntl(fd, F_GETFL, 0);
-	fcntl(fd, F_SETFL, v | O_NONBLOCK);
+        unsigned v;
+        v = fcntl(fd, F_GETFL, 0);
+        fcntl(fd, F_SETFL, v | O_NONBLOCK);
 #endif
 }
 
 static int
 set_tcp_sockopt(t_socket sockfd, int optname, int value)
 {
-	int level;
+        int level;
 #ifndef SOL_TCP
-	struct protoent *buf;
+        struct protoent *buf;
 
-	if ((buf = getprotobyname("tcp")) != NULL) {
-		level = buf->p_proto;
+        if ((buf = getprotobyname("tcp")) != NULL) {
+                level = buf->p_proto;
         } else {
-		return -1;
+                return -1;
         }
 #else
         level = SOL_TCP;
 #endif
 
-	return setsockopt(sockfd, level, optname, (char *)&value, sizeof(value));
+        return setsockopt(sockfd, level, optname, (char *)&value, sizeof(value));
 }
 
 int
@@ -729,7 +729,7 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
         /* ipv6 in [...] form ? */
         if (host[0] == '[') {
                 char *str;
-                
+
                 host++;
                 str = strchr(host, ']');
                 if (str == NULL) {
@@ -754,18 +754,18 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
         if (err != 0) {
                 free(addr);
 #ifdef _WINDOWS
-				if (err == WSANOTINITIALISED)
-				{
-					smb2_set_error(smb2, "Winsock was not initialized. "
-						"Please call WSAStartup().");
-					return -WSANOTINITIALISED; 
-				}
-				else
+                if (err == WSANOTINITIALISED)
+                {
+                        smb2_set_error(smb2, "Winsock was not initialized. "
+                                "Please call WSAStartup().");
+                        return -WSANOTINITIALISED; 
+                }
+                else
 #endif
-				{
-					smb2_set_error(smb2, "Invalid address:%s  "
-						"Can not resolv into IPv4/v6.", server);
-				}
+                {
+                        smb2_set_error(smb2, "Invalid address:%s  "
+                                "Can not resolv into IPv4/v6.", server);
+                }
                 switch (err) {
                     case EAI_AGAIN:
                         return -EAGAIN;
@@ -823,29 +823,28 @@ smb2_connect_async(struct smb2_context *smb2, const char *server,
         smb2->connect_cb   = cb;
         smb2->connect_data = private_data;
 
-      
-	smb2->fd = socket(family, SOCK_STREAM, 0);
-	if (smb2->fd == -1) {
-		smb2_set_error(smb2, "Failed to open smb2 socket. "
+        smb2->fd = socket(family, SOCK_STREAM, 0);
+        if (smb2->fd == -1) {
+                smb2_set_error(smb2, "Failed to open smb2 socket. "
                                "Errno:%s(%d).", strerror(errno), errno);
-		return -EIO;
-	}
+                return -EIO;
+        }
 
-	set_nonblocking(smb2->fd);
-	set_tcp_sockopt(smb2->fd, TCP_NODELAY, 1);
-        
-	if (connect(smb2->fd, (struct sockaddr *)&ss, socksize) != 0
+        set_nonblocking(smb2->fd);
+        set_tcp_sockopt(smb2->fd, TCP_NODELAY, 1);
+
+        if (connect(smb2->fd, (struct sockaddr *)&ss, socksize) != 0
 #ifndef _MSC_VER
-		  && errno != EINPROGRESS) {
+                  && errno != EINPROGRESS) {
 #else
-		  && WSAGetLastError() != WSAEWOULDBLOCK) {
+                  && WSAGetLastError() != WSAEWOULDBLOCK) {
 #endif
-		smb2_set_error(smb2, "Connect failed with errno : "
-			"%s(%d)", strerror(errno), errno);
-		close(smb2->fd);
-		smb2->fd = -1;
-		return -EIO;
-	}
+                smb2_set_error(smb2, "Connect failed with errno : "
+                        "%s(%d)", strerror(errno), errno);
+                close(smb2->fd);
+                smb2->fd = -1;
+                return -EIO;
+        }
 
         if (smb2->fd && smb2->change_fd) {
                 smb2->change_fd(smb2, smb2->fd, SMB2_ADD_FD);

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -734,15 +734,15 @@ connect_async_ai(struct smb2_context *smb2, struct addrinfo *ai,
         }
         family = ai->ai_family;
 
-        smb2->connect_cb   = cb;
-        smb2->connect_data = private_data;
-
         smb2->fd = socket(family, SOCK_STREAM, 0);
         if (smb2->fd == -1) {
                 smb2_set_error(smb2, "Failed to open smb2 socket. "
                                "Errno:%s(%d).", strerror(errno), errno);
                 return -EIO;
         }
+
+        smb2->connect_cb   = cb;
+        smb2->connect_data = private_data;
 
         set_nonblocking(smb2->fd);
         set_tcp_sockopt(smb2->fd, TCP_NODELAY, 1);
@@ -757,6 +757,8 @@ connect_async_ai(struct smb2_context *smb2, struct addrinfo *ai,
                         "%s(%d)", strerror(errno), errno);
                 close(smb2->fd);
                 smb2->fd = -1;
+                smb2->connect_cb = NULL;
+                smb2->connect_data = NULL;
                 return -EIO;
         }
 


### PR DESCRIPTION
getaddrinfo() returns a linked list of addresses. The first one is very likely an IPV6 address. Lot of servers don't accept IPV6 connections, resulting on a smb2_connect failure.

The solution is to try to connect to every address returned by getaddrinfo().

This fixes connection issues on a lot of popular NAS.