### PR TITLE
dcerpc: heap use after free between cb and free_pdu

### DIFF
--- a/lib/dcerpc.c
+++ b/lib/dcerpc.c
@@ -1409,8 +1409,11 @@ static void
 dcerpc_send_pdu_cb_and_free(struct dcerpc_context *dce, struct dcerpc_pdu *pdu,
                             int status, void *command_data)
 {
-        pdu->cb(dce, status, command_data, pdu->cb_data);
+        dcerpc_cb pdu_cb = pdu->cb;
+        void *pdu_cb_data = pdu->cb_data;
+
         dcerpc_free_pdu(dce, pdu);
+        pdu_cb(dce, status, command_data, pdu_cb_data);
 }
 
 static void


### PR DESCRIPTION
The dcerpc_context can be freed from pdu callbacks but was used after for freeing the pdu. So free the pdu using the dcerpc_context before calling callbacks.

```
    Asan trace:
    =218284==ERROR: AddressSanitizer: heap-use-after-free on address 0x6060006ff680 at pc 0x7f9104b4ed1b bp 0x7f9104d1bfc0 sp 0x7f9104d1bfb8
    READ of size 8 at 0x6060006ff680 thread T25
        #0 0x7f9104b4ed1a in dcerpc_free_pdu ../../lib/dcerpc.c:428
        #1 0x7f9104b4f7b7 in smb2_bind_cb ../../lib/dcerpc.c:1563
        #2 0x7f9104b561e7 in smb2_destroy_context ../../lib/init.c:320
        #3 0x7f9104bdab4d in vlc_smb2_open_share ../../modules/access/smb2.c:602
        #4 0x7f9104bdb5f3 in Open ../../modules/access/smb2.c:713

    0x6060006ff680 is located 0 bytes inside of 56-byte region [0x6060006ff680,0x6060006ff6b8)
    freed by thread T25 here:
        #0 0x7f912c570b6f in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.6+0xa9b6f)
        #1 0x7f9104b4eca7 in dcerpc_destroy_context ../../lib/dcerpc.c:417
        #2 0x7f9104b773df in share_enum_bind_cb ../../lib/smb2-share-enum.c:111
        #3 0x7f9104b4cc89 in dcerpc_bind_cb ../../lib/dcerpc.c:1540
        #4 0x7f9104b4f7ac in smb2_bind_cb ../../lib/dcerpc.c:1562
        #5 0x7f9104b561e7 in smb2_destroy_context ../../lib/init.c:320
        #6 0x7f9104bdab4d in vlc_smb2_open_share ../../modules/access/smb2.c:602
        #7 0x7f9104bdb5f3 in Open ../../modules/access/smb2.c:713
```