### PR TITLE
Changes to make libsmb2 compile for ESP32 with current esp-idf build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+if(NOT ESP_PLATFORM)
+
 cmake_minimum_required(VERSION 3.2)
 
 project(libsmb2
@@ -69,3 +71,74 @@ install(FILES cmake/FindSMB2.cmake
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libsmb2.pc
         DESTINATION ${INSTALL_PKGCONFIG_DIR})
+
+else() ##### ESP_PLATFORM
+
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    add_definitions(-DHAVE_CONFIG_H)
+endif()
+
+
+set(COMPONENT_ADD_INCLUDEDIRS
+    "lib"
+    include
+    include/smb2
+    include/esp
+    )
+
+set(COMPONENT_SRCS
+    lib/aes.c
+    lib/aes128ccm.c
+    lib/alloc.c
+    lib/dcerpc.c
+    lib/dcerpc-lsa.c
+    lib/dcerpc-srvsvc.c
+    lib/errors.c
+    lib/init.c
+    lib/hmac.c
+    lib/hmac-md5.c
+    lib/krb5-wrapper.c
+    lib/libsmb2.c
+    lib/md4c.c
+    lib/md5.c
+    lib/ntlmssp.c
+    lib/pdu.c
+    lib/sha1.c
+    lib/sha224-256.c
+    lib/sha384-512.c
+    lib/smb2-cmd-close.c
+    lib/smb2-cmd-create.c
+    lib/smb2-cmd-echo.c
+    lib/smb2-cmd-error.c
+    lib/smb2-cmd-flush.c
+    lib/smb2-cmd-ioctl.c
+    lib/smb2-cmd-logoff.c
+    lib/smb2-cmd-negotiate.c
+    lib/smb2-cmd-query-directory.c
+    lib/smb2-cmd-query-info.c
+    lib/smb2-cmd-read.c
+    lib/smb2-cmd-session-setup.c
+    lib/smb2-cmd-set-info.c
+    lib/smb2-cmd-tree-connect.c
+    lib/smb2-cmd-tree-disconnect.c
+    lib/smb2-cmd-write.c
+    lib/smb2-data-file-info.c
+    lib/smb2-data-filesystem-info.c
+    lib/smb2-data-security-descriptor.c
+    lib/smb2-data-reparse-point.c
+    lib/smb2-share-enum.c
+    lib/smb3-seal.c
+    lib/smb2-signing.c
+    lib/socket.c
+    lib/sync.c
+    lib/timestamps.c
+    lib/unicode.c
+    lib/usha.c
+
+    lib/compat.c)
+
+set(COMPONENT_NAME ".")
+
+register_component()
+
+endif() ##### ESP_PLATFORM

--- a/include/portable-endian.h
+++ b/include/portable-endian.h
@@ -15,6 +15,7 @@
 
 #if defined(ESP_PLATFORM)
 
+// These 4 #defines may be needed with older esp-idf environments
 //#       define _LITTLE_ENDIAN LITTLE_ENDIAN
 //#       define __bswap16     __bswap_16
 //#       define __bswap32     __bswap_32

--- a/include/portable-endian.h
+++ b/include/portable-endian.h
@@ -15,10 +15,10 @@
 
 #if defined(ESP_PLATFORM)
 
-#       define _LITTLE_ENDIAN LITTLE_ENDIAN
-#       define __bswap16     __bswap_16
-#       define __bswap32     __bswap_32
-#       define __bswap64     __bswap_64
+//#       define _LITTLE_ENDIAN LITTLE_ENDIAN
+//#       define __bswap16     __bswap_16
+//#       define __bswap32     __bswap_32
+//#       define __bswap64     __bswap_64
 
 #	include <endian.h>
 


### PR DESCRIPTION
For ESP32, the existing libsmb2 build instructions don't work with the current esp-idf CMake-based build system (see [issue #165](https://github.com/sahlberg/libsmb2/issues/165)), and portable_endian.h has #defines that appear to be superfluous and cause build errors.

I've changed the top-level CMakeLists.txt to add an ESP_PLATFORM-specific section, separate from the existing instructions, and I've commented out the offending #defines in portable_endian.h. With these changes, I'm able to add libsmb2 to an ESP32 project in the specified manner, build the project, and connect to both Linux and Windows SMB servers and write files to them. 

Furthermore, running CMake outside of an esp-idf context appears to run exactly the same way as it does without my changes — but I'm _not_ a CMake guru, so this should be properly tested by someone who _actually knows what they're doing_ to make sure I didn't break anything!

Additional disclaimer: the current build environment is said to (have) work(ed at some time in the past) for ESP32 builds. That may be the case for the legacy GNU Make-based build system (esp-idf before version 4.0). I don't _think_ I've changed anything that would break that, but I don't _know_, and I don't have an older make-based build system to test it with. The changes in portable_endian.h, for example, may need to be conditioned on whether it's the old or the new build system; those #defines may have been needed with older versions of the esp-idf libraries. 

(Apologies in advance if I've done this wrong. It's my first time; be (reasonably) gentle with me! :-) )