### PR TITLE
Using random value for client_guid instead of process id

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -292,7 +292,7 @@ struct smb2_context *smb2_init_context(void)
                 smb2->salt[i] = random() & 0xff;
         }
 
-        snprintf(smb2->client_guid, 16, "libsmb2-%d", random());
+        snprintf(smb2->client_guid, 16, "libsmb2-%d", (int)random());
 
         smb2->session_key = NULL;
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -292,7 +292,7 @@ struct smb2_context *smb2_init_context(void)
                 smb2->salt[i] = random() & 0xff;
         }
 
-        snprintf(smb2->client_guid, 16, "libsmb2-%d", getpid());
+        snprintf(smb2->client_guid, 16, "libsmb2-%d", random());
 
         smb2->session_key = NULL;
 


### PR DESCRIPTION
This fixed an issue with Microsoft Windows 10 SMB server returning `STATUS_USER_SESSION_DELETED` when opening multiple connections from within a service hosted in docker container (or multiple containers I would rather say). It was happening only when SMB protocol 3.1.1 was used. Negotiating 3.0.2 or lower version did also help, but that isn't good candidate for long term solution.