### PR TITLE
add opaque context member to smb2_context

### DIFF
--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -148,6 +148,8 @@ struct smb2_context {
         const char *workstation;
         char client_challenge[8];
 
+        void *opaque;
+
         smb2_command_cb connect_cb;
         void *connect_data;
 

--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -274,6 +274,17 @@ void smb2_set_domain(struct smb2_context *smb2, const char *domain);
  */
 void smb2_set_workstation(struct smb2_context *smb2, const char *workstation);
 
+/*
+ * Sets the address to some user defined object. May be used to make
+ * additional context data available in the async callbacks.
+ */
+void smb2_set_opaque(struct smb2_context *smb2, void *opaque);
+
+/*
+ * Returns the opaque pointer set with smb2_set_opaque.
+ */
+void *smb2_get_opaque(struct smb2_context *smb2);
+
 
 /*
  * Returns the client_guid for this context.

--- a/lib/init.c
+++ b/lib/init.c
@@ -547,6 +547,16 @@ void smb2_set_workstation(struct smb2_context *smb2, const char *workstation)
         smb2->workstation = strdup(workstation);
 }
 
+void smb2_set_opaque(struct smb2_context *smb2, void *opaque)
+{
+        smb2->opaque = opaque;
+}
+
+void *smb2_get_opaque(struct smb2_context *smb2)
+{
+        return smb2->opaque;
+}
+
 void smb2_set_seal(struct smb2_context *smb2, int val)
 {
         smb2->seal = val;

--- a/lib/libsmb2.syms
+++ b/lib/libsmb2.syms
@@ -47,6 +47,7 @@ smb2_get_fds
 smb2_get_file_id
 smb2_get_max_read_size
 smb2_get_max_write_size
+smb2_get_opaque
 smb2_init_context
 smb2_mkdir
 smb2_mkdir_async
@@ -80,6 +81,7 @@ smb2_set_user
 smb2_set_password
 smb2_set_domain
 smb2_set_workstation
+smb2_set_opaque
 smb2_set_seal
 smb2_set_sign
 smb2_set_timeout


### PR DESCRIPTION
Implements #190. 

libsmb2 already allows context to be passed to async functions, for instance a directory name in the callback for an async directory listing. However, if you want to use the library in an OOP way, you always want some state object to be reachable from within a callback. In that case you'd need to wrap both in another struct, which creates overhead and is just cumbersome.

This commit basically allows you to set and get this state object anywhere you want, freeing the `private_data` for the thing that is specific to that async call.

It can also be called something other than `opaque`.