### PR TITLE
Fix shared folder with ; or @ issue

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -210,14 +210,21 @@ struct smb2_url *smb2_parse_url(struct smb2_context *smb2, const char *url)
 
         ptr = str;
 
+        char *shared_folder = strchr(ptr, '/');
+        if (!shared_folder) {
+                smb2_set_error(smb2, "Wrong URL format");
+                return NULL;
+        }
+        int len_shared_folder = strlen(shared_folder);
+
         /* domain */
-        if ((tmp = strchr(ptr, ';')) != NULL) {
+        if ((tmp = strchr(ptr, ';')) != NULL && strlen(tmp) > len_shared_folder) {
                 *(tmp++) = '\0';
                 u->domain = strdup(ptr);
                 ptr = tmp;
         }
         /* user */
-        if ((tmp = strchr(ptr, '@')) != NULL) {
+        if ((tmp = strchr(ptr, '@')) != NULL && strlen(tmp) > len_shared_folder) {
                 *(tmp++) = '\0';
                 u->user = strdup(ptr);
                 ptr = tmp;


### PR DESCRIPTION
smb2_parse_url function needs an URL with the format :
smb://[<domain;][<username>@]<server>/<share>/<path>

When optional args are not provided, the parser will still search them
and maybe find them in the <share>/<path>. If the delimiters ; or @
are found in it, this will pose a problem to analyze the parsing.

Fixes #84