### PR TITLE
change ucs2 to utf16

### DIFF
--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -268,21 +268,21 @@ struct smb2_pdu {
         time_t timeout;
 };
 
-/* UCS2 is always in Little Endianness */
-struct ucs2 {
+/* SMB's UTF-16 is always in Little Endian */
+struct utf16 {
         int len;
         uint16_t val[1];
 };
 
-/* Returns a string converted to UCS2 format. Use free() to release
- * the ucs2 string.
+/* Returns a string converted to UTF-16 format. Use free() to release
+ * the utf16 string.
  */
-struct ucs2 *utf8_to_ucs2(const char *utf8);
+struct utf16 *utf8_to_utf16(const char *utf8);
         
 /* Returns a string converted to UTF8 format. Use free() to release
  * the utf8 string.
  */
-const char *ucs2_to_utf8(const uint16_t *str, int len);
+const char *utf16_to_utf8(const uint16_t *str, int len);
 
 /* Convert a win timestamp to a unix timeval */
 void win_to_timeval(uint64_t smb2_time, struct smb2_timeval *tv);

--- a/include/smb2/libsmb2-dcerpc.h
+++ b/include/smb2/libsmb2-dcerpc.h
@@ -102,9 +102,9 @@ int dcerpc_uint32_coder(struct dcerpc_context *ctx, struct dcerpc_pdu *pdu,
                      struct smb2_iovec *iov, int offset, void *ptr);
 int dcerpc_uint3264_coder(struct dcerpc_context *ctx, struct dcerpc_pdu *pdu,
                        struct smb2_iovec *iov, int offset, void *ptr);
-int dcerpc_ucs2_coder(struct dcerpc_context *ctx, struct dcerpc_pdu *pdu,
+int dcerpc_utf16_coder(struct dcerpc_context *ctx, struct dcerpc_pdu *pdu,
                       struct smb2_iovec *iov, int offset, void *ptr);
-int dcerpc_ucs2z_coder(struct dcerpc_context *ctx, struct dcerpc_pdu *pdu,
+int dcerpc_utf16z_coder(struct dcerpc_context *ctx, struct dcerpc_pdu *pdu,
                         struct smb2_iovec *iov, int offset, void *ptr);
 int dcerpc_context_handle_coder(struct dcerpc_context *dce,
                                 struct dcerpc_pdu *pdu,

--- a/lib/dcerpc-lsa.c
+++ b/lib/dcerpc-lsa.c
@@ -203,7 +203,7 @@ lsa_RPC_UNICODE_STRING_coder(struct dcerpc_context *dce,
         offset = dcerpc_uint16_coder(dce, pdu, iov, offset, &len);
         offset = dcerpc_uint16_coder(dce, pdu, iov, offset, &maxlen);
         offset = dcerpc_ptr_coder(dce, pdu, iov, offset, ptr,
-                                   PTR_UNIQUE, dcerpc_ucs2_coder);
+                                   PTR_UNIQUE, dcerpc_utf16_coder);
 
         return offset;
 }
@@ -370,7 +370,7 @@ lsa_OpenPolicy2_req_coder(struct dcerpc_context *dce,
         struct lsa_openpolicy2_req *req = ptr;
 
         offset = dcerpc_ptr_coder(dce, pdu, iov, offset, &req->SystemName,
-                                   PTR_UNIQUE, dcerpc_ucs2z_coder);
+                                   PTR_UNIQUE, dcerpc_utf16z_coder);
         offset = dcerpc_ptr_coder(dce, pdu, iov, offset, &req->ObjectAttributes,
                                    PTR_REF, lsa_ObjectAttributes_coder);
         offset = dcerpc_uint32_coder(dce, pdu, iov, offset, &req->DesiredAccess);

--- a/lib/dcerpc-srvsvc.c
+++ b/lib/dcerpc-srvsvc.c
@@ -88,10 +88,10 @@ srvsvc_NetShareInfo1_coder(struct dcerpc_context *ctx,
         struct srvsvc_netshareinfo1 *nsi1 = ptr;
 
         offset = dcerpc_ptr_coder(ctx, pdu, iov, offset, &nsi1->name,
-                                   PTR_UNIQUE, dcerpc_ucs2z_coder);
+                                   PTR_UNIQUE, dcerpc_utf16z_coder);
         offset = dcerpc_uint32_coder(ctx, pdu, iov, offset, &nsi1->type);
         offset = dcerpc_ptr_coder(ctx, pdu, iov, offset, &nsi1->comment,
-                                   PTR_UNIQUE, dcerpc_ucs2z_coder);
+                                   PTR_UNIQUE, dcerpc_utf16z_coder);
         return offset;
 }
 
@@ -211,7 +211,7 @@ srvsvc_NetrShareEnum_req_coder(struct dcerpc_context *ctx,
         struct srvsvc_netsharectr ctr;
 
         offset = dcerpc_ptr_coder(ctx, pdu, iov, offset, &req->server,
-                                   PTR_UNIQUE, dcerpc_ucs2z_coder);
+                                   PTR_UNIQUE, dcerpc_utf16z_coder);
         offset = dcerpc_ptr_coder(ctx, pdu, iov, offset, &req->level,
                                    PTR_REF, dcerpc_uint32_coder);
         ctr.level = 1;
@@ -318,10 +318,10 @@ srvsvc_NetrShareGetInfo_req_coder(struct dcerpc_context *dce,
         struct srvsvc_netrsharegetinfo_req *req = ptr;
 
         offset = dcerpc_ptr_coder(dce, pdu, iov, offset, &req->ServerName,
-                                  PTR_UNIQUE, dcerpc_ucs2z_coder);
+                                  PTR_UNIQUE, dcerpc_utf16z_coder);
         offset = dcerpc_ptr_coder(dce, pdu, iov, offset,
                                   discard_const(&req->NetName),
-                                  PTR_REF, dcerpc_ucs2z_coder);
+                                  PTR_REF, dcerpc_utf16z_coder);
         offset = dcerpc_uint32_coder(dce, pdu, iov, offset, &req->Level);
 
         return offset;

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -130,9 +130,9 @@ struct connect_data {
         const char *share;
         const char *user;
 
-        /* UNC for the share in utf8 as well as ucs2 formats */
+        /* UNC for the share in utf8 as well as utf16 formats */
         char *utf8_unc;
-        struct ucs2 *ucs2_unc;
+        struct utf16 *utf16_unc;
 
         void *auth_data;
 };
@@ -517,7 +517,7 @@ free_c_data(struct smb2_context *smb2, struct connect_data *c_data)
         }
 
         free(c_data->utf8_unc);
-        free(c_data->ucs2_unc);
+        free(c_data->utf16_unc);
         free(discard_const(c_data->server));
         free(discard_const(c_data->share));
         free(discard_const(c_data->user));
@@ -765,8 +765,8 @@ session_setup_cb(struct smb2_context *smb2, int status,
 
         memset(&req, 0, sizeof(struct smb2_tree_connect_request));
         req.flags       = 0;
-        req.path_length = 2 * c_data->ucs2_unc->len;
-        req.path        = c_data->ucs2_unc->val;
+        req.path_length = 2 * c_data->utf16_unc->len;
+        req.path        = c_data->utf16_unc->val;
 
         pdu = smb2_cmd_tree_connect_async(smb2, &req, tree_connect_cb, c_data);
         if (pdu == NULL) {
@@ -1059,9 +1059,9 @@ smb2_connect_share_async(struct smb2_context *smb2,
                 return -ENOMEM;
         }
 
-        c_data->ucs2_unc = utf8_to_ucs2(c_data->utf8_unc);
-        if (c_data->ucs2_unc == NULL) {
-                smb2_set_error(smb2, "Count not convert UNC:[%s] into UCS2",
+        c_data->utf16_unc = utf8_to_utf16(c_data->utf8_unc);
+        if (c_data->utf16_unc == NULL) {
+                smb2_set_error(smb2, "Count not convert UNC:[%s] into UTF-16",
                                c_data->utf8_unc);
                 free_c_data(smb2, c_data);
                 return -ENOMEM;

--- a/lib/ntlmssp.c
+++ b/lib/ntlmssp.c
@@ -213,24 +213,24 @@ static int
 ntlm_convert_password_hash(const char *password, unsigned char password_hash[16])
 {
         int i, hn, ln;
-        struct ucs2 *ucs2_password = NULL;
+        struct utf16 *utf16_password = NULL;
 
-        ucs2_password = utf8_to_ucs2(password);
-        if (ucs2_password == NULL) {
+        utf16_password = utf8_to_utf16(password);
+        if (utf16_password == NULL) {
                 return -1;
         }
 
         for (i = 0; i < 32; i++) {
-                if (islower((unsigned int) ucs2_password->val[i])) {
-                        ucs2_password->val[i] = toupper((unsigned int) ucs2_password->val[i]);
+                if (islower((unsigned int) utf16_password->val[i])) {
+                        utf16_password->val[i] = toupper((unsigned int) utf16_password->val[i]);
                 }
         }
 
         /* FreeRDP: winpr/libwinpr/sspi/NTLM/ntlm_compute.c */
         for (i = 0; i < 32; i += 2)
         {
-                hn = ucs2_password->val[i] > '9' ? ucs2_password->val[i] - 'A' + 10 : ucs2_password->val[i] - '0';
-                ln = ucs2_password->val[i + 1] > '9' ? ucs2_password->val[i + 1] - 'A' + 10 : ucs2_password->val[i + 1] - '0';
+                hn = utf16_password->val[i] > '9' ? utf16_password->val[i] - 'A' + 10 : utf16_password->val[i] - '0';
+                ln = utf16_password->val[i + 1] > '9' ? utf16_password->val[i + 1] - 'A' + 10 : utf16_password->val[i + 1] - '0';
                 password_hash[i / 2] = (hn << 4) | ln;
         }
 
@@ -241,16 +241,16 @@ static int
 NTOWFv1(const char *password, unsigned char password_hash[16])
 {
         MD4_CTX ctx;
-        struct ucs2 *ucs2_password = NULL;
+        struct utf16 *utf16_password = NULL;
 
-        ucs2_password = utf8_to_ucs2(password);
-        if (ucs2_password == NULL) {
+        utf16_password = utf8_to_utf16(password);
+        if (utf16_password == NULL) {
                 return -1;
         }
         MD4Init(&ctx);
-        MD4Update(&ctx, (unsigned char *)ucs2_password->val, ucs2_password->len * 2);
+        MD4Update(&ctx, (unsigned char *)utf16_password->val, utf16_password->len * 2);
         MD4Final(password_hash, &ctx);
-        free(ucs2_password);
+        free(utf16_password);
 
         return 0;
 }
@@ -261,7 +261,7 @@ NTOWFv2(const char *user, const char *password, const char *domain,
 {
         int i, len;
         char *userdomain;
-        struct ucs2 *ucs2_userdomain = NULL;
+        struct utf16 *utf16_userdomain = NULL;
         unsigned char ntlm_hash[16];
 
         /* ntlm:F638EDF864C4805DC65D9BF2BB77E4C0 */
@@ -294,17 +294,17 @@ NTOWFv2(const char *user, const char *password, const char *domain,
                 strcat(userdomain, domain);
         }
 
-        ucs2_userdomain = utf8_to_ucs2(userdomain);
-        if (ucs2_userdomain == NULL) {
+        utf16_userdomain = utf8_to_utf16(userdomain);
+        if (utf16_userdomain == NULL) {
                 free(userdomain);
                 return -1;
         }
 
-        smb2_hmac_md5((unsigned char *)ucs2_userdomain->val,
-                 ucs2_userdomain->len * 2,
+        smb2_hmac_md5((unsigned char *)utf16_userdomain->val,
+                 utf16_userdomain->len * 2,
                  ntlm_hash, 16, ntlmv2_hash);
         free(userdomain);
-        free(ucs2_userdomain);
+        free(utf16_userdomain);
 
         return 0;
 }
@@ -358,9 +358,9 @@ encode_ntlm_auth(struct smb2_context *smb2, time_t ti,
         unsigned char lm_buf[16];
         unsigned char *NTChallengeResponse_buf = NULL;
         unsigned char ResponseKeyNT[16];
-        struct ucs2 *ucs2_domain = NULL;
-        struct ucs2 *ucs2_user = NULL;
-        struct ucs2 *ucs2_workstation = NULL;
+        struct utf16 *utf16_domain = NULL;
+        struct utf16 *utf16_user = NULL;
+        struct utf16 *utf16_workstation = NULL;
         int NTChallengeResponse_len = 0;
         unsigned char NTProofStr[16];
         unsigned char LMStr[16];
@@ -460,11 +460,11 @@ encode_ntlm_auth(struct smb2_context *smb2, time_t ti,
 
         /* domain name fields */
         if (!anonymous && auth_data->domain) {
-                ucs2_domain = utf8_to_ucs2(auth_data->domain);
-                if (ucs2_domain == NULL) {
+                utf16_domain = utf8_to_utf16(auth_data->domain);
+                if (utf16_domain == NULL) {
                         goto finished;
                 }
-                u32 = ucs2_domain->len * 2;
+                u32 = utf16_domain->len * 2;
                 u32 = htole32((u32 << 16) | u32);
                 encoder(&u32, 4, auth_data);
                 u32 = 0;
@@ -477,11 +477,11 @@ encode_ntlm_auth(struct smb2_context *smb2, time_t ti,
 
         /* user name fields */
         if (!anonymous) {
-                ucs2_user = utf8_to_ucs2(auth_data->user);
-                if (ucs2_user == NULL) {
+                utf16_user = utf8_to_utf16(auth_data->user);
+                if (utf16_user == NULL) {
                         goto finished;
                 }
-                u32 = ucs2_user->len * 2;
+                u32 = utf16_user->len * 2;
                 u32 = htole32((u32 << 16) | u32);
                 encoder(&u32, 4, auth_data);
                 u32 = 0;
@@ -494,11 +494,11 @@ encode_ntlm_auth(struct smb2_context *smb2, time_t ti,
 
         /* workstation name fields */
         if (!anonymous && auth_data->workstation) {
-                ucs2_workstation = utf8_to_ucs2(auth_data->workstation);
-                if (ucs2_workstation == NULL) {
+                utf16_workstation = utf8_to_utf16(auth_data->workstation);
+                if (utf16_workstation == NULL) {
                         goto finished;
                 }
-                u32 = ucs2_workstation->len * 2;
+                u32 = utf16_workstation->len * 2;
                 u32 = htole32((u32 << 16) | u32);
                 encoder(&u32, 4, auth_data);
                 u32 = 0;
@@ -533,22 +533,22 @@ encode_ntlm_auth(struct smb2_context *smb2, time_t ti,
                 /* append domain */
                 u32 = htole32(auth_data->len);
                 memcpy(&auth_data->buf[32], &u32, 4);
-                if (ucs2_domain) {
-                        encoder(ucs2_domain->val, ucs2_domain->len * 2,
+                if (utf16_domain) {
+                        encoder(utf16_domain->val, utf16_domain->len * 2,
                                 auth_data);
                 }
 
                 /* append user */
                 u32 = htole32(auth_data->len);
                 memcpy(&auth_data->buf[40], &u32, 4);
-                encoder(ucs2_user->val, ucs2_user->len * 2, auth_data);
+                encoder(utf16_user->val, utf16_user->len * 2, auth_data);
 
                 /* append workstation */
                 u32 = htole32(auth_data->len);
                 memcpy(&auth_data->buf[48], &u32, 4);
-                if (ucs2_workstation) {
-                        encoder(ucs2_workstation->val,
-                                ucs2_workstation->len * 2, auth_data);
+                if (utf16_workstation) {
+                        encoder(utf16_workstation->val,
+                                utf16_workstation->len * 2, auth_data);
                 }
 
                 /* append LMChallengeResponse */
@@ -566,9 +566,9 @@ encode_ntlm_auth(struct smb2_context *smb2, time_t ti,
 
         ret = 0;
 finished:
-        free(ucs2_domain);
-        free(ucs2_user);
-        free(ucs2_workstation);
+        free(utf16_domain);
+        free(utf16_user);
+        free(utf16_workstation);
         free(NTChallengeResponse_buf);
 
         return ret;

--- a/lib/smb2-cmd-create.c
+++ b/lib/smb2-cmd-create.c
@@ -55,7 +55,7 @@ smb2_encode_create_request(struct smb2_context *smb2,
         int i, len;
         uint8_t *buf;
         uint16_t ch;
-        struct ucs2 *name = NULL;
+        struct utf16 *name = NULL;
         struct smb2_iovec *iov;
 
         len = SMB2_CREATE_REQUEST_SIZE & 0xfffffffe;
@@ -69,9 +69,9 @@ smb2_encode_create_request(struct smb2_context *smb2,
 
         /* Name */
         if (req->name && req->name[0]) {
-                name = utf8_to_ucs2(req->name);
+                name = utf8_to_utf16(req->name);
                 if (name == NULL) {
-                        smb2_set_error(smb2, "Could not convert name into UCS2");
+                        smb2_set_error(smb2, "Could not convert name into UTF-16");
                         return -1;
                 }
                 /* name length */

--- a/lib/smb2-cmd-query-directory.c
+++ b/lib/smb2-cmd-query-directory.c
@@ -76,7 +76,7 @@ smb2_decode_fileidfulldirectoryinformation(
         smb2_get_uint32(vec, 64, &fs->ea_size);
         smb2_get_uint64(vec, 72, &fs->file_id);
 
-        fs->name = ucs2_to_utf8((uint16_t *)&vec->buf[80], name_len / 2);
+        fs->name = utf16_to_utf8((uint16_t *)&vec->buf[80], name_len / 2);
 
         smb2_get_uint64(vec, 8, &t);
         win_to_timeval(t, &fs->creation_time);
@@ -100,7 +100,7 @@ smb2_encode_query_directory_request(struct smb2_context *smb2,
 {
         int len;
         uint8_t *buf;
-        struct ucs2 *name = NULL;
+        struct utf16 *name = NULL;
         struct smb2_iovec *iov;
 
         len = SMB2_QUERY_DIRECTORY_REQUEST_SIZE & 0xfffffffe;
@@ -114,9 +114,9 @@ smb2_encode_query_directory_request(struct smb2_context *smb2,
 
         /* Name */
         if (req->name && req->name[0]) {
-                name = utf8_to_ucs2(req->name);
+                name = utf8_to_utf16(req->name);
                 if (name == NULL) {
-                        smb2_set_error(smb2, "Could not convert name into UCS2");
+                        smb2_set_error(smb2, "Could not convert name into UTF-16");
                         return -1;
                 }
                 smb2_set_uint16(iov, 26, 2 * name->len);

--- a/lib/smb2-cmd-set-info.c
+++ b/lib/smb2-cmd-set-info.c
@@ -112,9 +112,9 @@ smb2_encode_set_info_request(struct smb2_context *smb2,
                 case SMB2_FILE_RENAME_INFORMATION:
                         rni = req->input_data;
 
-                        struct ucs2 *name = utf8_to_ucs2((char *)(rni->file_name));
+                        struct utf16 *name = utf8_to_utf16((char *)(rni->file_name));
                         if (name == NULL) {
-                                smb2_set_error(smb2, "Could not convert name into UCS2");
+                                smb2_set_error(smb2, "Could not convert name into UTF-16");
                                 return -1;
                         }
                         /* Convert '/' to '\' */

--- a/lib/smb2-data-file-info.c
+++ b/lib/smb2-data-file-info.c
@@ -155,7 +155,7 @@ smb2_decode_file_all_info(struct smb2_context *smb2,
         smb2_get_uint32(vec, 92, &fs->alignment_requirement);
         smb2_get_uint16(vec, 96, &name_len);
 
-        name = ucs2_to_utf8((uint16_t *)&vec->buf[100], name_len / 2);
+        name = utf16_to_utf8((uint16_t *)&vec->buf[100], name_len / 2);
         fs->name = smb2_alloc_data(smb2, memctx, strlen(name) + 1);
         if (fs->name == NULL) {
                 free(discard_const(name));

--- a/lib/smb2-data-filesystem-info.c
+++ b/lib/smb2-data-filesystem-info.c
@@ -60,7 +60,7 @@ smb2_decode_file_fs_volume_info(struct smb2_context *smb2,
 	smb2_get_uint32(vec, 12, &fs->volume_label_length);
 	smb2_get_uint8(vec,  16, &fs->supports_objects);
 	smb2_get_uint8(vec,  17, &fs->reserved);
-        name = ucs2_to_utf8((uint16_t *)&vec->buf[18],
+        name = utf16_to_utf8((uint16_t *)&vec->buf[18],
                             fs->volume_label_length / 2);
         fs->volume_label = smb2_alloc_data(smb2, memctx, strlen(name) + 1);
         if (fs->volume_label == NULL) {

--- a/lib/smb2-data-reparse-point.c
+++ b/lib/smb2-data-reparse-point.c
@@ -77,7 +77,7 @@ smb2_decode_reparse_data_buffer(struct smb2_context *smb2,
                         return -1;
                 }
 
-                tmp = ucs2_to_utf8((uint16_t *)(&vec->buf[suboffset + 20]),
+                tmp = utf16_to_utf8((uint16_t *)(&vec->buf[suboffset + 20]),
                                    sublen / 2);
                 rp->symlink.subname = smb2_alloc_data(smb2, rp,
                                                       strlen(tmp) + 1);
@@ -93,7 +93,7 @@ smb2_decode_reparse_data_buffer(struct smb2_context *smb2,
                 if (printoffset + printlen + 12 > rp->reparse_data_length) {
                         return -1;
                 }
-                tmp = ucs2_to_utf8((uint16_t *)(&vec->buf[printoffset + 20]),
+                tmp = utf16_to_utf8((uint16_t *)(&vec->buf[printoffset + 20]),
                                    printlen / 2);
                 rp->symlink.printname = smb2_alloc_data(smb2, rp,
                                                         strlen(tmp) + 1);

--- a/lib/unicode.c
+++ b/lib/unicode.c
@@ -61,39 +61,74 @@ l1(char c)
 
 /* Validates that utf8 points to a valid utf8 codepoint.
  * Will update **utf8 to point at the next character in the string.
- * return 0 if the encoding is valid and
- * -1 if not.
+ * return 1 if the encoding is valid and requires one UTF-16 code unit,
+ * 2 if the encoding is valid and requires two UTF-16 code units
+ * -1 if it's invalid.
  * If the encoding is valid the codepoint will be returned in *cp.
  */
 static int
-validate_utf8_cp(const char **utf8, uint16_t *cp)
+validate_utf8_cp(const char **utf8, uint16_t *ret)
 {
         int c = *(*utf8)++;
-        int l = l1(c);
+        int l, l_tmp;
+        l = l_tmp = l1(c);
+        uint32_t cp;
 
         switch (l) {
         case 0:
                 /* 7-bit ascii is always ok */
-                *cp = c & 0x7f;
-                return 0;
+                *ret = c & 0x7f;
+                return 1;
         case 1:
                 /* 10.. .... can never start a new codepoint */
                 return -1;
         case 2:
         case 3:
-                *cp = c & 0x1f;
-                /* 2 and 3 byte sequences must always be followed by exactly
-                 * 1 or 2 chars matching 10.. .... 
+        case 4:
+                cp = c & (0x7f >> l);
+                /* 2, 3 and 4 byte sequences must always be followed by exactly
+                 * 1, 2 or 3 chars matching 10.. ....
                  */
-                while(--l) {
+                while(--l_tmp) {
                         c = *(*utf8)++;
                         if (l1(c) != 1) {
                                 return -1;
                         }
-                        *cp <<= 6;
-                        *cp |= (c & 0x3f);
+                        cp <<= 6;
+                        cp |= (c & 0x3f);
                 }
-                return 0;
+
+                /* Check for overlong sequences */
+                switch (l) {
+                case 2:
+                        if (cp < 0x80) return -1;
+                        break;
+                case 3:
+                        if (cp < 0x800) return -1;
+                        break;
+                case 4:
+                        if (cp < 0x10000) return -1;
+                        break;
+                default: break;
+                }
+
+                /* Write the code point in either one or two UTC-16 code units */
+                if (cp < 0xd800 || (cp - 0xe000) < 0x2000) {
+                        /* Single UTF-16 code unit */
+                        *ret = cp;
+                        return 1;
+                } else if (cp < 0xe000) {
+                        /* invalid unicode range */
+                        return -1;
+                } else if (cp < 0x110000) {
+                        cp -= 0x10000;
+                        *ret = 0xd800 | (cp >> 10);
+                        *(ret+1) = 0xdc00 | (cp & 0x3ff) ;
+                        return 2;
+                } else {
+                        /* invalid unicode range */
+                        return -1;
+                }
         }
         return -1;
 }
@@ -106,22 +141,24 @@ validate_utf8_str(const char *utf8)
 {
         const char *u = utf8;
         int i = 0;
-        uint16_t cp;
-        
+        int cp_length;
+        uint16_t cp[2];
+
         while (*u) {
-                if (validate_utf8_cp(&u, &cp) < 0) {
+                cp_length = validate_utf8_cp(&u, cp);
+                if (cp_length < 0) {
                         return -1;
                 }
-                i++;
+                i += cp_length;
         }
         return i;
 }
 
-/* Convert a UTF8 string into UCS2 Little Endian */
-struct ucs2 *
-utf8_to_ucs2(const char *utf8)
+/* Convert a UTF8 string into UTF-16LE */
+struct utf16 *
+utf8_to_utf16(const char *utf8)
 {
-        struct ucs2 *ucs2;
+        struct utf16 *utf16;
         int i, len;
 
         len = validate_utf8_str(utf8);
@@ -129,70 +166,131 @@ utf8_to_ucs2(const char *utf8)
                 return NULL;
         }
 
-        ucs2 = malloc(offsetof(struct ucs2, val) + 2 * len);
-        if (ucs2 == NULL) {
+        utf16 = (struct utf16 *)(malloc(offsetof(struct utf16, val) + 2 * len));
+        if (utf16 == NULL) {
                 return NULL;
         }
 
-        ucs2->len = len;
-        for (i = 0; i < len; i++) {
-                validate_utf8_cp(&utf8, &ucs2->val[i]);
-                ucs2->val[i] = htole16(ucs2->val[i]);
+        utf16->len = len;
+        i = 0;
+        while (i < len) {
+                switch(validate_utf8_cp(&utf8, &utf16->val[i])) {
+                case 1:
+                    utf16->val[i] = htole16(utf16->val[i]);
+                    i += 1;
+                    break;
+                case 2:
+                    utf16->val[i] = htole16(utf16->val[i]);
+                    utf16->val[i+1] = htole16(utf16->val[i+1]);
+                    i += 2;
+                    break;
+                default:
+                    /* Won't happen since we wouldn't have gotten here if the UTF-8 string was invalid */
+                    break;
+                }
         }
-        
-        return ucs2;
+
+        return utf16;
 }
 
-/* Returns how many bytes we need to store a UCS2 codepoint
- */
 static int
-ucs2_cp_size(uint16_t cp)
+utf16_size(const uint16_t *utf16, int utf16_len)
 {
-        if (cp > 0x07ff) {
-                return 3;
+        int length = 0;
+        const uint16_t *utf16_end = utf16 + utf16_len;
+        while (utf16 < utf16_end) {
+                uint32_t code = le16toh(*utf16++);
+
+                if (code < 0x80) {
+                        length += 1; /* One UTF-16 code unit maps to one UTF-8 code unit */
+                } else if (code < 0x800) {
+                        length += 2; /* One UTF-16 code unit maps to two UTF-8 code units */
+                } else if (code < 0xd800 || code - 0xe000 < 0x2000) {
+                        length += 3;
+                } else if (code < 0xdc00) { /* Surrogate pair */
+
+                        if (utf16 == utf16_end) { /* It's possible the stream ends with a leading code unit, which is an error */
+                                return length + 3; /* Replacement char */
+                        }
+
+                        uint32_t trail = le16toh(*utf16);
+                        if (trail - 0xdc00 < 0x400) { /* Check that 0xdc00 <= trail < 0xe000 */
+                                code = 0x10000 + ((code & 0x3ff) << 10) + (trail & 0x3ff);
+                                if (code < 0x10000) {
+                                        length += 3; /* Two UTF-16 code units map to three UTF-8 code units */
+                                } else {
+                                        length += 4; /* Two UTF-16 code units map to four UTF-8 code units */
+                                }
+                                utf16++;
+                        } else { /* Invalid trailing code unit. It's still valid on its own though so only the first unit gets replaced */
+                                length += 3; /* Replacement char */
+                        }
+                } else { /* 0xdc00 <= code < 0xe00, which makes code a trailing code unit without a leading one, which is invalid */
+                        length += 3; /* Replacement char */
+                }
         }
-        if (cp > 0x007f) {
-                return 2;
-        }
-        return 1;
+
+        return length;
 }
 
 /*
- * Convert a UCS2 string into UTF8
+ * Convert a UTF-16LE string into UTF8
  */
 const char *
-ucs2_to_utf8(const uint16_t *ucs2, int ucs2_len)
+utf16_to_utf8(const uint16_t *utf16, int utf16_len)
 {
-        int i, utf8_len = 1;
+        int utf8_len = 1;
         char *str, *tmp;
 
         /* How many bytes do we need for utf8 ? */
-        for (i = 0; i < ucs2_len; i++) {
-                utf8_len += ucs2_cp_size(ucs2[i]);
-        }
-        str = tmp = malloc(utf8_len);
+        utf8_len += utf16_size(utf16, utf16_len);
+        str = tmp = (char*)malloc(utf8_len);
         if (str == NULL) {
                 return NULL;
         }
         str[utf8_len - 1] = 0;
 
-        for (i = 0; i < ucs2_len; i++) {
-                uint16_t c = le16toh(ucs2[i]);
-                int l = ucs2_cp_size(c);
+        const uint16_t *utf16_end = utf16 + utf16_len;
+        while (utf16 < utf16_end) {
+                uint32_t code = le16toh(*utf16++);
 
-                switch (l) {
-                case 3:
-                        *tmp++ = 0xe0 |  (c >> 12);
-                        *tmp++ = 0x80 | ((c >>  6) & 0xbf);
-                        *tmp++ = 0x80 | ((c      ) & 0xbf);
-                        break;
-                case 2:
-                        *tmp++ = 0xc0 |  (c >> 6);
-                        *tmp++ = 0x80 | ((c     ) & 0xbf);
-                        break;
-                case 1:
-                        *tmp++ = c;
-                        break;
+                if (code < 0x80) {
+                        *tmp++ = code; /* One UTF-16 code unit maps to one UTF-8 code unit */
+                } else if (code < 0x800) {
+                        *tmp++ = 0xc0 |  (code >> 6);         /* One UTF-16 code unit maps to two UTF-8 code units */
+                        *tmp++ = 0x80 | ((code     ) & 0x3f);
+                } else if (code < 0xD800 || code - 0xe000 < 0x2000) {
+                        *tmp++ = 0xe0 |  (code >> 12);         /* All other values where we only have one UTF-16 code unit map to 3 UTF-8 code units */
+                        *tmp++ = 0x80 | ((code >>  6) & 0x3f);
+                        *tmp++ = 0x80 | ((code      ) & 0x3f);
+                } else if (code < 0xdc00) { /* Surrogate pair */
+
+                        if (utf16 == utf16_end) { /* It's possible the stream ends with a leading code unit, which is an error */
+                                *tmp++ = 0xef; *tmp++ = 0xbf; *tmp++ = 0xbd; /* Replacement char */
+                                return str;
+                        }
+
+                        uint32_t trail = le16toh(*utf16);
+                        if (trail - 0xdc00 < 0x400) { /* Check that 0xdc00 <= trail < 0xe000 */
+                                code = 0x10000 + ((code & 0x3ff) << 10) + (trail & 0x3ff);
+                                if (code < 0x10000) {
+                                        *tmp++ = 0xe0 |  (code >> 12);
+                                        *tmp++ = 0x80 | ((code >>  6) & 0x3f);
+                                        *tmp++ = 0x80 | ((code      ) & 0x3f);
+                                } else {
+                                        *tmp++ = 0xF0 | (code >> 18);
+                                        *tmp++ = 0x80 | ((code >> 12) & 0x3F);
+                                        *tmp++ = 0x80 | ((code >> 6) & 0x3F);
+                                        *tmp++ = 0x80 | (code & 0x3F);
+                                }
+                                utf16++;
+                        } else {
+                                /* Invalid trailing code unit. It's still valid on its own though so only the first unit gets replaced */
+                                *tmp++ = 0xef; *tmp++ = 0xbf; *tmp++ = 0xbd; /* Replacement char */
+                        }
+                } else {
+                        /* 0xdc00 <= code < 0xe00, which makes code a trailing code unit without a leading one, which is invalid */
+                        *tmp++ = 0xef; *tmp++ = 0xbf; *tmp++ = 0xbd; /* Replacement char */
                 }
         }
 


### PR DESCRIPTION
Fixes #207 

**Additional changes**

Besides changing conversion from and to UCS-2 to UTF-16, I also added checks for:
- overlong UTF-8 sequences in. If left unchecked overlong sequences could result in hard to debug bugs and possibly security vulnerabilities.
- invalid UTF-16 code units. These are now replaced with Unicode replacement chars (U+FFFD: �).

Both these additional checks make the transcoding functions behave the same as [ICU](http://site.icu-project.org/). (Actually `validate_utf8_cp` simply rejects invalid strings completely whereas ICU replaces invalid characters, but the code rejects all input for which ICU would replace one or more characters). 

**Tests**

I also wrote a simple test suite in C++ which basically compares the unicode.c functions' output with ICU's. It requires the ICU libraries, I believe `libicu-dev` is the package you need in Debian based systems. Copy&paste unicode.c's functions (`l1`, `validate_utf8_cp`, `validate_utf8_str`, `validate_utf8_str`, `utf8_to_utf16`, `utf16_size` and `utf16_to_utf8`) into it, compile with:
```
g++ <filename> `pkg-config --libs --cflags icu-uc icu-io`
```
No errors on stderr means success.

Test code:

```C++
#include <cstring>
#include <iostream>
#include <unicode/unistr.h>
#include <unicode/ustream.h>


struct utf16 {
        int len;
        uint16_t val[1];
};


void test_utf16_to_utf8(const char16_t *val, int length) {
        icu::UnicodeString icu16{val};
        std::string icu8;
        icu16.toUTF8String(icu8);

        if (utf16_size((const uint16_t*)val, length) != icu8.length()) {
                std::cerr << "Size calculation failed: " << utf16_size((const uint16_t *)val, length) << " != " << icu8.length() << " (icu value=\"" << icu8 << "\")\n";
                exit(1);
        }

        const char *utf8 = utf16_to_utf8((const uint16_t*)val, length);

        if (std::strlen(utf8) != icu8.length()) {
                std::cerr << "Strings have unequal length: " << std::strlen(utf8) << ", " << icu8.length() << " (icu value=\"" << icu8 << "\")\n";
                exit(1);
        }

        if (std::strcmp(utf8, icu8.c_str()) != 0) {
                std::cerr << "Strings have unequal value: " << utf8 << ", " << icu8 << ")\n";
                exit(1);
        }

        delete utf8;
}


void test_utf8_to_utf16(const char *val) {
        icu::UnicodeString icu16 = icu::UnicodeString::fromUTF8(val);
        int utf16_length = validate_utf8_str(val);

        // Our reaction to invalid UTF-8 is to simply reject it, ie validate_utf8_str returns -1
        // ICU will replace invalid chars. To check that we correctly reject invalid strings, look for the replacement char in icu16
        if (utf16_length == -1 && icu16.indexOf(0xfffd) != -1) {
                return;
        }

        if (utf16_length != icu16.length()) {
                std::cerr << "Size calculation failed: " << utf16_length << " != " << icu16.length() << " (icu value=\"" << icu16 << "\")\n";
                exit(1);
        }

        struct utf16 *utf16 = utf8_to_utf16(val);

        for (unsigned i=0; i<utf16_length; ++i) {
                if (utf16->val[i] != icu16.getBuffer()[i]) {
                        std::cerr << "Strings have unequal value: " << utf16 << " != " << icu16 << "\n";
                        exit(1);
                }
        }

        delete utf16;
}


void utf16_to_utf8() {
        char16_t val[4];
        val[2] = 0;
        val[3] = 0;
    
        // Valid lower range code unit: 0 < code < 0xd800
        for (uint32_t i=1; i<0xd800; ++i) {
                val[0] = i;
                val[1] = 0;
                test_utf16_to_utf8(val, 1);

                // Followed by another code unit
                val[0] = i;
                val[1] = 0x41;
                test_utf16_to_utf8(val, 2);
        }

        // Valid upper range single code unit: 0xe000 <= code < 0x10000
        for (uint32_t i=0xe000; i<0x10000; ++i) {
                val[0] = i;
                val[1] = 0;
                test_utf16_to_utf8(val, 1);

                // Followed by another code unit
                val[0] = i;
                val[1] = 0x41;
                test_utf16_to_utf8(val, 2);
        }

        // Valid surrogate pair: 0xd800 <= leading < 0xdc00, 0xdc00 <= trailing < 0xe000
        for (uint32_t i=0xd800; i<0xdc00; ++i) {
                for (uint32_t j=0xdc00; j<0xe000; ++j) {
                        val[0] = i;
                        val[1] = j;
                        val[2] = 0;
                        test_utf16_to_utf8(val, 2);

                        // Followed by another code unit
                        val[0] = i;
                        val[1] = j;
                        val[2] = 0x41;
                        test_utf16_to_utf8(val, 3);
                }
        } 
        val[2] = 0;
    
        // Invalid surrogate pair: 0xd800 <= leading < 0xdc00 (which is ok), but 0 < trailing < 0xdc00 or 0xe00 <= trailing < 0x10000
        for (uint32_t i=0xd800; i<0xdc00; ++i) {
                for (uint32_t j=1; j<0xdc00; ++j) {
                        val[0] = i;
                        val[1] = j;
                        val[2] = 0;
                        test_utf16_to_utf8(val, 2);

                        // Followed by another code unit
                        val[0] = i;
                        val[1] = j;
                        val[2] = 0x41;
                        test_utf16_to_utf8(val, 3);
                }

                for (uint32_t j=0xe000; j<0x10000; ++j) {
                        val[0] = i;
                        val[1] = j;
                        val[2] = 0;
                        test_utf16_to_utf8(val, 2);

                        // Followed by another code unit
                        val[0] = i;
                        val[1] = j;
                        val[2] = 0x41;
                        test_utf16_to_utf8(val, 3);
                }
        } 
        val[2] = 0;

        // Invalid code unit: trailing code unit without a leading one, ie 0xdc00 <= code < 0xe000
        for (uint32_t i=0xdc00; i<0xe000; ++i) {
                val[0] = i;
                val[1] = 0;
                test_utf16_to_utf8(val, 1);

                // Followed by another code unit
                val[0] = i;
                val[1] = 0x41;
                test_utf16_to_utf8(val, 2);
        }

        // Invalid code unit: trailing code unit without a leading one, ie 0xdc00 <= code < 0xe000, multiple times
        for (uint32_t i=0xdc00; i<0xe000; ++i) {
                for (uint32_t j=0xdc00; j<0xe000; ++j) {
                        val[0] = i;
                        val[1] = j;
                        val[2] = 0;
                        test_utf16_to_utf8(val, 2);

                        // Followed by another code unit
                        val[0] = i;
                        val[1] = j;
                        val[2] = 0x41;
                        test_utf16_to_utf8(val, 3);
                }
        }
        val[2] = 0x0;

        // Empty string
        val[0] = 0;
        test_utf16_to_utf8(val, 0);
}


void utf8_to_utf16() {
        char val[6];
        val[1] = 0;
        val[2] = 0;
        val[3] = 0;
        val[4] = 0;
        val[5] = 0;

        for (unsigned i=1; i<0x80; ++i) {
                val[0] = i;
                val[1] = 0;
                test_utf8_to_utf16(val);

                // Followed by another code unit
                val[1] = 0x41;
                test_utf8_to_utf16(val);
        }

        // Two code unit sequence
        for (unsigned i=0; i<0x20; ++i) {
                for (unsigned j=0; j<0x40; ++j) {
                        val[0] = (0xc0 | i);
                        val[1] = 0x80 | j;
                        val[2] = 0;
                        test_utf8_to_utf16(val);

                        // Followed by another code unit
                        val[0] = (0xc0 | i);
                        val[1] = 0x80 | j;
                        val[2] = 0x41;
                        test_utf8_to_utf16(val);
                }
        }
        
        // Three code unit sequence
        for (unsigned i=0; i<0x10; ++i) {
                for (unsigned j=0; j<0x40; ++j) {
                        for (unsigned k=0; k<0x40; ++k) {
                                val[0] = 0xe0 | i;
                                val[1] = 0x80 | j;
                                val[2] = 0x80 | k;
                                val[3] = 0;
                                test_utf8_to_utf16(val);

                                // Followed by another code unit
                                val[0] = 0xe0 | i;
                                val[1] = 0x80 | j;
                                val[2] = 0x80 | k;
                                val[3] = 0x41;
                                test_utf8_to_utf16(val);
                        }
                }
        }
        
        // Four code unit sequence
        for (unsigned i=0; i<0x8; ++i) {
                for (unsigned j=0; j<0x40; ++j) {
                        for (unsigned k=0; k<0x40; ++k) {
                                for (unsigned l=0; l<0x40; ++l) {
                                        val[0] = 0xf0 | i;
                                        val[1] = 0x80 | j;
                                        val[2] = 0x80 | k;
                                        val[3] = 0x80 | l;
                                        val[4] = 0;
                                        test_utf8_to_utf16(val);

                                        // Followed by another code unit
                                        val[0] = 0xf0 | i;
                                        val[1] = 0x80 | j;
                                        val[2] = 0x80 | k;
                                        val[3] = 0x41;
                                        test_utf8_to_utf16(val);
                                }
                        }
                }
        }

        // Invalid single code unit sequence, all starting with the highest bit set
        val[1] = 0;
        for (unsigned i=0; i<7; ++i) {
                val[0] = 0xff << i;
                test_utf8_to_utf16(val);
        }

        // Empty string
        val[0] = 0;
        test_utf8_to_utf16(val);
}


int main() {
        utf16_to_utf8();
        utf8_to_utf16();
}
```