### PR TITLE
Add upload to ESP component service workflow

### DIFF
--- a/.github/workflows/esp_upload_component.yml
+++ b/.github/workflows/esp_upload_component.yml
@@ -1,0 +1,18 @@
+name: Push libsmb2 to Espressif Component Service
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Upload component to component service
+        uses: espressif/github-actions/upload_components@master
+        with:
+          name: "libsmb2"
+          namespace: "sahlberg"
+          api_token: ${{ secrets.ESP_IDF_COMPONENT_API_TOKEN }}

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,5 @@
+version: "3.0.1"
+description: Libsmb2 is a userspace client library for accessing SMB2/SMB3 shares on a network
+url: https://github.com/sahlberg/libsmb2
+dependencies:
+  idf: ">=4.2"


### PR DESCRIPTION
### Description of the feature or fix
This PR adds a workflow for uploading to Espressif's component service. ATM, it is published on every push to `master` branch, but it can be changed to upload on successful release on GitHub, if you plan to use them.
Please also note that you need to bump component version in `idf_component.yml` before uploading it, otherwise the component service won't accept the new version.

Idf-component-manager is a new function that allows ESP-IDF users to integrate software package into their project seamlessly.
More information about idf-component manager can be found in [Espressif API guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html) or [PyPi registry](https://pypi.org/project/idf-component-manager/). The component service itself is hosted [here](https://components.espressif.com/).

In order to upload to Espressif's registry, an API token must be added to Github secrets (see [.github/workflows/esp_upload_component.yml  line 18](https://github.com/tore-espressif/libsmb2/blob/e727413a41645e4c3842b6fee8a116bed2032216/.github/workflows/esp_upload_component.yml#L18)), I can send it to you in private message, if you agree.

Closes https://github.com/espressif/esp-idf/issues/3574

### Checkpoints
- [ ] Add ESP_IDF token to Github secrets