### PR TITLE
fix mismatched bound build error

### DIFF
--- a/lib/sha224-256.c
+++ b/lib/sha224-256.c
@@ -338,7 +338,7 @@ SHA256FinalBits (SHA256Context * context,
  *   sha Error Code.
  */
 int
-SHA256Result (SHA256Context * context, uint8_t Message_Digest[])
+SHA256Result (SHA256Context * context, uint8_t Message_Digest[SHA256HashSize])
 {
   return SHA224_256ResultN (context, Message_Digest, SHA256HashSize);
 }


### PR DESCRIPTION
With gcc (Debian 11.3.0-4) 11.3.0:

../../lib/sha224-256.c:341:48: error: argument 2 of type ‘uint8_t[]’ {aka ‘unsigned char[]’} with mismatched bound [-Werror=array-parameter=]
  341 | SHA256Result (SHA256Context * context, uint8_t Message_Digest[])
      |                                        ~~~~~~~~^~~~~~~~~~~~~~~~