### PR TITLE
build/cmake: only include OpenSSL include directory if it is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,11 @@ include(cmake/ConfigureChecks.cmake)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}
                     include
-                    include/smb2
-                    ${OPENSSL_INCLUDE_DIR})
+                    include/smb2)
+
+if(OPENSSL_FOUND)
+  include_directories(${OPENSSL_INCLUDE_DIR})
+endif()
 
 set(core_DEPENDS ${GSSAPI_LIBRARIES} CACHE STRING "" FORCE)
 


### PR DESCRIPTION
Fixes CMake build when OpenSSL is not found