### PR TITLE
do not sign tree connect requests for guest sessions

### DIFF
--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -637,6 +637,10 @@ session_setup_cb(struct smb2_context *smb2, int status,
                 smb2->sign = 0;
         }
 
+        if (rep->session_flags & SMB2_SESSION_FLAG_IS_GUEST) {
+                smb2->sign = 0;
+        }
+
 #ifdef HAVE_LIBKRB5
        if (smb2->sec == SMB2_SEC_KRB5) {
                 /* For NTLM the status will be

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -369,7 +369,7 @@ smb2_queue_pdu(struct smb2_context *smb2, struct smb2_pdu *pdu)
         for (p = pdu; p; p = p->next_compound) {
                 smb2_encode_header(smb2, &p->out.iov[0], &p->header);
                 if (smb2->sign ||
-                    (p->header.command == SMB2_TREE_CONNECT && smb2->dialect == SMB2_VERSION_0311 && !smb2->seal)) {
+                    (p->header.command == SMB2_TREE_CONNECT && smb2->dialect == SMB2_VERSION_0311 && !smb2->seal && smb2->sign)) {
                         if (smb2_pdu_add_signature(smb2, p) < 0) {
                                 smb2_set_error(smb2, "Failure to add "
                                                "signature. %s",


### PR DESCRIPTION
Fixes the cases where credentials are provided even though the server does not require them (and maps the user to the guest account).

This currently works:
  ./examples/smb-ls-async smb://127.0.0.1/testshare

While this fails:
  NTLM_USER_FILE=auth.txt ./examples/smb-ls-async smb://user@127.0.0.1/share