### PR TITLE
give access to nterror

### DIFF
--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -213,6 +213,7 @@ struct smb2_context {
         uint16_t dialect;
 
         char error_string[MAX_ERROR_SIZE];
+        int nterror;
 
         /* Open filehandles */
         struct smb2fh *fhs;
@@ -292,6 +293,8 @@ uint64_t timeval_to_win(struct smb2_timeval *tv);
 
 void smb2_set_error(struct smb2_context *smb2, const char *error_string,
                     ...);
+void smb2_set_nterror(struct smb2_context *smb2, int nterror,
+                    const char *error_string, ...);
 
 void smb2_close_connecting_fds(struct smb2_context *smb2);
 

--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -373,6 +373,8 @@ int smb2_disconnect_share(struct smb2_context *smb2);
  */
 const char *smb2_get_error(struct smb2_context *smb2);
 
+int smb2_get_nterror(struct smb2_context *smb2);
+
 struct smb2_url {
         const char *domain;
         const char *user;

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -413,7 +413,7 @@ query_cb(struct smb2_context *smb2, int status,
                 return;
         }
 
-        smb2_set_error(smb2, "Query directory failed with (0x%08x) %s. %s",
+        smb2_set_nterror(smb2, status, "Query directory failed with (0x%08x) %s. %s",
                        status, nterror_to_str(status),
                        smb2_get_error(smb2));
         dir->cb(smb2, -nterror_to_errno(status), NULL, dir->cb_data);
@@ -430,7 +430,7 @@ opendir_cb(struct smb2_context *smb2, int status,
         struct smb2_pdu *pdu;
 
         if (status != SMB2_STATUS_SUCCESS) {
-                smb2_set_error(smb2, "Opendir failed with (0x%08x) %s.",
+                smb2_set_nterror(smb2, status, "Opendir failed with (0x%08x) %s.",
                                status, nterror_to_str(status));
                 dir->cb(smb2, -nterror_to_errno(status), NULL, dir->cb_data);
                 free_smb2dir(smb2, dir);
@@ -533,7 +533,7 @@ tree_connect_cb(struct smb2_context *smb2, int status,
 
         if (status != SMB2_STATUS_SUCCESS) {
                 smb2_close_context(smb2);
-                smb2_set_error(smb2, "Tree Connect failed with (0x%08x) %s. %s",
+                smb2_set_nterror(smb2, status, "Tree Connect failed with (0x%08x) %s. %s",
                                status, nterror_to_str(status),
                                smb2_get_error(smb2));
                 c_data->cb(smb2, -nterror_to_errno(status), NULL, c_data->cb_data);
@@ -624,7 +624,7 @@ session_setup_cb(struct smb2_context *smb2, int status,
 
         } else if (status != SMB2_STATUS_SUCCESS) {
                 smb2_close_context(smb2);
-                smb2_set_error(smb2, "Session setup failed with (0x%08x) %s",
+                smb2_set_nterror(smb2, status, "Session setup failed with (0x%08x) %s",
                                status, nterror_to_str(status));
                 c_data->cb(smb2, -nterror_to_errno(status), NULL,
                            c_data->cb_data);
@@ -838,7 +838,7 @@ negotiate_cb(struct smb2_context *smb2, int status,
 
         if (status != SMB2_STATUS_SUCCESS) {
                 smb2_close_context(smb2);
-                smb2_set_error(smb2, "Negotiate failed with (0x%08x) %s. %s",
+                smb2_set_nterror(smb2, status, "Negotiate failed with (0x%08x) %s. %s",
                                status, nterror_to_str(status),
                                smb2_get_error(smb2));
                 c_data->cb(smb2, -nterror_to_errno(status), NULL,
@@ -1101,7 +1101,7 @@ open_cb(struct smb2_context *smb2, int status,
         struct smb2_create_reply *rep = command_data;
 
         if (status != SMB2_STATUS_SUCCESS) {
-                smb2_set_error(smb2, "Open failed with (0x%08x) %s.",
+                smb2_set_nterror(smb2, status, "Open failed with (0x%08x) %s.",
                                status, nterror_to_str(status));
                 fh->cb(smb2, -nterror_to_errno(status), NULL, fh->cb_data);
                 free_smb2fh(smb2, fh);
@@ -1205,7 +1205,7 @@ close_cb(struct smb2_context *smb2, int status,
         struct smb2fh *fh = private_data;
 
         if (status != SMB2_STATUS_SUCCESS) {
-                smb2_set_error(smb2, "Close failed with (0x%08x) %s",
+                smb2_set_nterror(smb2, status, "Close failed with (0x%08x) %s",
                                status, nterror_to_str(status));
                 fh->cb(smb2, -nterror_to_errno(status), NULL, fh->cb_data);
                 free_smb2fh(smb2, fh);
@@ -1255,7 +1255,7 @@ fsync_cb(struct smb2_context *smb2, int status,
         struct smb2fh *fh = private_data;
 
         if (status != SMB2_STATUS_SUCCESS) {
-                smb2_set_error(smb2, "Flush failed with (0x%08x) %s",
+                smb2_set_nterror(smb2, status, "Flush failed with (0x%08x) %s",
                                status, nterror_to_str(status));
                 fh->cb(smb2, -nterror_to_errno(status), NULL, fh->cb_data);
                 return;
@@ -1310,7 +1310,7 @@ read_cb(struct smb2_context *smb2, int status,
         struct smb2_read_reply *rep = command_data;
 
         if (status && status != SMB2_STATUS_END_OF_FILE) {
-                smb2_set_error(smb2, "Read/Write failed with (0x%08x) %s",
+                smb2_set_nterror(smb2, status, "Read/Write failed with (0x%08x) %s",
                                status, nterror_to_str(status));
                 rd->cb(smb2, -nterror_to_errno(status), &rd->read_cb_data, rd->cb_data);
                 free(rd);
@@ -1429,7 +1429,7 @@ write_cb(struct smb2_context *smb2, int status,
         struct smb2_write_reply *rep = command_data;
 
         if (status && status != SMB2_STATUS_END_OF_FILE) {
-                smb2_set_error(smb2, "Read/Write failed with (0x%08x) %s",
+                smb2_set_nterror(smb2, status, "Read/Write failed with (0x%08x) %s",
                                status, nterror_to_str(status));
                 wd->cb(smb2, -nterror_to_errno(status), &wd->write_cb_data, wd->cb_data);
                 free(wd);
@@ -2410,7 +2410,7 @@ readlink_cb_1(struct smb2_context *smb2, int status,
         struct readlink_cb_data *cb_data = private_data;
 
         if (status != SMB2_STATUS_SUCCESS) {
-                smb2_set_error(smb2, "%s", nterror_to_str(status));
+                smb2_set_nterror(smb2, status, "%s", nterror_to_str(status));
         }
         cb_data->status = status;
 }


### PR DESCRIPTION
Most of the time, the real **nterror** is much more explicit than a mapping to errors defined in **errno.h**.

Here is a patch to be able to get this error, if it is not related to the protocol you get 0 (== success).