### PR TITLE
Fix ntlm_convert_password_hash on big endian

### DIFF
--- a/lib/ntlmssp.c
+++ b/lib/ntlmssp.c
@@ -221,6 +221,7 @@ ntlm_convert_password_hash(const char *password, unsigned char password_hash[16]
         }
 
         for (i = 0; i < 32; i++) {
+                utf16_password->val[i] = le16toh(utf16_password->val[i]);
                 if (islower((unsigned int) utf16_password->val[i])) {
                         utf16_password->val[i] = toupper((unsigned int) utf16_password->val[i]);
                 }


### PR DESCRIPTION
Using NTLM hashes didn't work on big endian systems, because utf8_to_utf16 always converts to little endian. A byteswap is required before parsing the hash string on these systems.