### PR TITLE
Add ESP-IDF 5.x support

### DIFF
--- a/lib/smb3-seal.c
+++ b/lib/smb3-seal.c
@@ -22,6 +22,10 @@
 #ifdef ESP_PLATFORM
 #include <esp_system.h>
 #include <sys/types.h>
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#include <esp_random.h>
+#endif
 #define random esp_random
 #endif
 


### PR DESCRIPTION
https://docs.espressif.com/projects/esp-idf/en/v5.0.1/esp32/migration-guides/release-5.x/system.html#esp-system says:

The header files esp_random.h, esp_mac.h, and esp_chip_info.h, which were all previously indirectly included via the header file esp_system.h, must now be included directly. These indirect inclusions from esp_system.h have been removed.