### PR TITLE
Update CMakeLists.txt to remove OpenSSL references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,11 @@ if(NOT ESP_PLATFORM)
 
     include_directories(${CMAKE_CURRENT_BINARY_DIR}
                         include
-                        include/smb2
-                        ${OPENSSL_INCLUDE_DIR})
+                        include/smb2)
+    
+    if(OPENSSL_FOUND)
+      include_directories(${OPENSSL_INCLUDE_DIR})
+    endif()
 
     set(core_DEPENDS ${GSSAPI_LIBRARIES} CACHE STRING "" FORCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ if(NOT ESP_PLATFORM)
 
     project(libsmb2
             LANGUAGES C
-            VERSION 4.0.0)
+            VERSION 4.0.0
+    )
 
     set(SOVERSION 1 CACHE STRING "" FORCE)
 
@@ -90,25 +91,17 @@ if(NOT ESP_PLATFORM)
     list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
     find_package(GSSAPI)
-    find_package(OpenSSL)
 
     if(GSSAPI_FOUND)
       add_definitions(-DHAVE_LIBKRB5)
-    endif()
-
-    if(OPENSSL_FOUND)
-      add_definitions(-DHAVE_OPENSSL_LIBS)
     endif()
 
     include(cmake/ConfigureChecks.cmake)
 
     include_directories(${CMAKE_CURRENT_BINARY_DIR}
                         include
-                        include/smb2)
-    
-    if(OPENSSL_FOUND)
-      include_directories(${OPENSSL_INCLUDE_DIR})
-    endif()
+                        include/smb2
+    )
 
     set(core_DEPENDS ${GSSAPI_LIBRARIES} CACHE STRING "" FORCE)
 
@@ -168,7 +161,7 @@ else() ##### ESP_PLATFORM
     include
     include/smb2
     include/esp
-    )
+  )
 
   set(COMPONENT_SRCS
     lib/aes.c
@@ -218,8 +211,8 @@ else() ##### ESP_PLATFORM
     lib/timestamps.c
     lib/unicode.c
     lib/usha.c
-
-    lib/compat.c)
+    lib/compat.c
+  )
 
   set(COMPONENT_NAME ".")
 


### PR DESCRIPTION
Basically a copy from https://github.com/sahlberg/libsmb2/pull/235
Only add openssl include directory if found.
This fix allows me to build on Windows, without having OpenSSL installed.

You say "Libsmb2 does not use or depend on openssl"-  then I guess we should remove all references to it entirely, but not sure if there's some other files that need to be altered too.