### PR TITLE
Fix bounds checks to where we read fields from the NTLM buffer

### DIFF
--- a/lib/ntlmssp.c
+++ b/lib/ntlmssp.c
@@ -414,7 +414,7 @@ encode_ntlm_auth(struct smb2_context *smb2, time_t ti,
         u32 = le32toh(u32);
         /* Server name must fit in the buffer */
         if (u32 >= auth_data->ntlm_len ||
-            (u32 + server_name_len) >= auth_data->ntlm_len) {
+            (u32 + server_name_len) > auth_data->ntlm_len) {
                 goto finished;
         }
         server_name_buf = (char *)&auth_data->ntlm_buf[u32];


### PR DESCRIPTION
Fix the bounds checks to where we read fields from the NTLM buffer when parsing the challenge packet from the server.