### PR TITLE
ps2: Fix linking with old posix implementations

### DIFF
--- a/lib/compat.c
+++ b/lib/compat.c
@@ -53,53 +53,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-int getaddrinfo(const char *node, const char*service,
-                const struct addrinfo *hints,
-                struct addrinfo **res)
-{
-        struct sockaddr_in *sin;
-        struct hostent *host;
-        int i, ip[4];
-
-        sin = malloc(sizeof(struct sockaddr_in));
-        sin->sin_len = sizeof(struct sockaddr_in);
-        sin->sin_family=AF_INET;
-
-        /* Some error checking would be nice */
-        if (sscanf(node, "%d.%d.%d.%d", ip, ip+1, ip+2, ip+3) == 4) {
-                for (i = 0; i < 4; i++) {
-                        ((char *)&sin->sin_addr.s_addr)[i] = ip[i];
-                }
-        } else {
-                host = gethostbyname(node);
-                if (host == NULL) {
-                        return -1;
-                }
-                if (host->h_addrtype != AF_INET) {
-                        return -2;
-                }
-                memcpy(&sin->sin_addr.s_addr, host->h_addr, 4);
-        }
-
-        sin->sin_port=0;
-        if (service) {
-                sin->sin_port=htons(atoi(service));
-        } 
-
-        *res = malloc(sizeof(struct addrinfo));
-
-        (*res)->ai_family = AF_INET;
-        (*res)->ai_addrlen = sizeof(struct sockaddr_in);
-        (*res)->ai_addr = (struct sockaddr *)sin;
-
-        return 0;
-}
-
-void freeaddrinfo(struct addrinfo *res)
-{
-        free(res->ai_addr);
-        free(res);
-}
 
 #endif /* PS2_EE_PLATFORM */
 

--- a/lib/compat.h
+++ b/lib/compat.h
@@ -36,11 +36,8 @@ long long int be64toh(long long int x);
 #include <sys/time.h>
 
 #include <ps2ip.h>
-#define write(a,b,c) lwip_write(a,b,c)
-#define read(a,b,c) lwip_read(a,b,c)
-#undef gethostbyname /* PS2SDK has gethostbyname defined */
-#define gethostbyname(a) lwip_gethostbyname(a)
-#define close(a) lwip_close(a)
+#include <fcntl.h>
+#include <unistd.h>
 
 #define getlogin_r(a,b) ENXIO
 
@@ -65,11 +62,6 @@ struct iovec {
 
 ssize_t writev(int fd, const struct iovec *iov, int iovcnt);
 ssize_t readv(int fd, const struct iovec *iov, int iovcnt);
-
-int getaddrinfo(const char *node, const char*service,
-                const struct addrinfo *hints,
-                struct addrinfo **res);
-void freeaddrinfo(struct addrinfo *res);
 
 long long int be64toh(long long int x);
 


### PR DESCRIPTION
This fixes a problem that libsmb2 and libnfs, Doesn´t link/compile properly with smbLaunchelf
image sample:
![Screenshot_6](https://github.com/sahlberg/libsmb2/assets/75867486/01d24547-3260-4704-8d99-318d2adc461d)
