### PR TITLE
ESP_PLATFORM is sys/poll.h, not poll.h

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -45,7 +45,11 @@
 #endif
 
 #ifdef HAVE_POLL_H
+#ifdef ESP_PLATFORM
+#include <sys/poll.h>
+#else
 #include <poll.h>
+#endif
 #endif
 
 #ifdef HAVE_STDLIB_H

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -42,7 +42,11 @@
 #endif
 
 #ifdef HAVE_POLL_H
+#ifdef ESP_PLATFORM
+#include <sys/poll.h>
+#else
 #include <poll.h>
+#endif
 #endif
 
 #ifdef HAVE_STRING_H


### PR DESCRIPTION
ESP_PLATFORM has HAVE_POLL_H defined, but in sys/poll.h instead of poll.h.