### PR TITLE
Silence warning from MSVC and Convert C99 comment to C89

### DIFF
--- a/include/smb2/smb2.h
+++ b/include/smb2/smb2.h
@@ -586,12 +586,21 @@ struct smb2_set_info_request {
  */
 #define SID_ID_AUTH_LEN 6
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning( disable : 4200 ) /* Silence c4200 warning. */
+#endif
+
 struct smb2_sid {
         uint8_t revision;
         uint8_t sub_auth_count;
         uint8_t id_auth[SID_ID_AUTH_LEN];
         uint32_t sub_auth[0];
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 /*
  * ACE

--- a/lib/dcerpc-srvsvc.c
+++ b/lib/dcerpc-srvsvc.c
@@ -72,13 +72,14 @@ p_syntax_id_t srvsvc_interface = {
 /*
  * SRVSVC BEGIN:  DEFINITIONS FROM SRVSVC.IDL
  */
-/*
-	typedef struct {
-		[string,charset(UTF16)] uint16 *name;
-		srvsvc_ShareType type;
-		[string,charset(UTF16)] uint16 *comment;
-	} srvsvc_NetShareInfo1;
-*/
+#if 0
+typedef struct {
+	[string,charset(UTF16)] uint16 *name;
+	srvsvc_ShareType type;
+	[string,charset(UTF16)] uint16 *comment;
+} srvsvc_NetShareInfo1;
+#endif
+
 static int
 srvsvc_NetShareInfo1_coder(struct dcerpc_context *ctx,
                            struct dcerpc_pdu *pdu,
@@ -120,12 +121,13 @@ srvsvc_NetShareInfo1_array_coder(struct dcerpc_context *ctx,
         return offset;
 }
 
-/*
-	typedef struct {
-		uint32 count;
-		[size_is(count)] srvsvc_NetShareInfo1 *array;
-	} srvsvc_NetShareCtr1;
-*/
+#if 0
+typedef struct {
+	uint32 count;
+	[size_is(count)] srvsvc_NetShareInfo1 *array;
+} srvsvc_NetShareCtr1;
+#endif
+
 static int
 srvsvc_NetShareCtr1_coder(struct dcerpc_context *dce, struct dcerpc_pdu *pdu,
                           struct smb2_iovec *iov, int offset,
@@ -152,21 +154,22 @@ srvsvc_NetShareCtr1_coder(struct dcerpc_context *dce, struct dcerpc_pdu *pdu,
         return offset;
 }
 
-/*
-	typedef union {
-		[case(0)] srvsvc_NetShareCtr0 *ctr0;
-		[case(1)] srvsvc_NetShareCtr1 *ctr1;
-		[case(2)] srvsvc_NetShareCtr2 *ctr2;
-		[case(501)] srvsvc_NetShareCtr501 *ctr501;
-		[case(502)] srvsvc_NetShareCtr502 *ctr502;
-		[case(1004)] srvsvc_NetShareCtr1004 *ctr1004;
-		[case(1005)] srvsvc_NetShareCtr1005 *ctr1005;
-		[case(1006)] srvsvc_NetShareCtr1006 *ctr1006;
-		[case(1007)] srvsvc_NetShareCtr1007 *ctr1007;
-		[case(1501)] srvsvc_NetShareCtr1501 *ctr1501;
-		[default] ;
-	} srvsvc_NetShareCtr;
-*/
+#if 0
+typedef union {
+	[case(0)] srvsvc_NetShareCtr0 *ctr0;
+	[case(1)] srvsvc_NetShareCtr1 *ctr1;
+	[case(2)] srvsvc_NetShareCtr2 *ctr2;
+	[case(501)] srvsvc_NetShareCtr501 *ctr501;
+	[case(502)] srvsvc_NetShareCtr502 *ctr502;
+	[case(1004)] srvsvc_NetShareCtr1004 *ctr1004;
+	[case(1005)] srvsvc_NetShareCtr1005 *ctr1005;
+	[case(1006)] srvsvc_NetShareCtr1006 *ctr1006;
+	[case(1007)] srvsvc_NetShareCtr1007 *ctr1007;
+	[case(1501)] srvsvc_NetShareCtr1501 *ctr1501;
+	[default] ;
+} srvsvc_NetShareCtr;
+#endif
+
 static int
 srvsvc_NetShareCtr_coder(struct dcerpc_context *ctx, struct dcerpc_pdu *pdu,
                          struct smb2_iovec *iov, int offset,

--- a/lib/dcerpc.c
+++ b/lib/dcerpc.c
@@ -224,8 +224,9 @@ struct dcerpc_pdu {
 
         /* optional authentication verifier */
         /* following fields present iff auth_length != 0 */
-        /*auth_verifier_co_t   auth_verifier; */
-
+#if 0
+        auth_verifier_co_t   auth_verifier; 
+#endif
         struct dcerpc_context *dce;
         dcerpc_cb cb;
         void *cb_data;

--- a/lib/errors.c
+++ b/lib/errors.c
@@ -1176,7 +1176,7 @@ int nterror_to_errno(uint32_t status) {
         case SMB2_STATUS_INSUFFICIENT_RESOURCES:
                 return EBUSY;
         case SMB2_STATUS_INTERNAL_ERROR:
-                // Fall through.
+                /* Fall through. */
         default:
                 return EIO;
         }

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -110,11 +110,12 @@ static const char SmbSign[] = "SmbSign";
 static const char SMB2AESCCM[] = "SMB2AESCCM";
 static const char ServerOut[] = "ServerOut";
 static const char ServerIn[] = "ServerIn ";
-/* The following strings will be used for deriving other keys
+/* The following strings will be used for deriving other keys */
+#if 0
 static const char SMB2APP[] = "SMB2APP";
 static const char SmbRpc[] = "SmbRpc";
 static const char SMBAppKey[] = "SMBAppKey";
-*/
+#endif
 
 #ifndef O_ACCMODE
 #define O_ACCMODE (O_RDWR|O_WRONLY|O_RDONLY)

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -144,9 +144,11 @@ MD5Final(md5byte digest[16], struct MD5Context *ctx)
 #ifndef ASM_MD5
 
 /* The four core functions - F1 is optimized somewhat */
-
-/* #define F1(x, y, z) (x & y | ~x & z) */
+#if 0
+#define F1(x, y, z) (x & y | ~x & z) 
+#else
 #define F1(x, y, z) (z ^ (x & (y ^ z)))
+#endif
 #define F2(x, y, z) F1(z, x, y)
 #define F3(x, y, z) (x ^ y ^ z)
 #define F4(x, y, z) (y ^ (x | ~z))

--- a/lib/sha384-512.c
+++ b/lib/sha384-512.c
@@ -816,18 +816,18 @@ SHA384_512ProcessMessageBlock (SHA512Context * context)
 
   for (t = t2 = 0; t < 80; t++, t2 += 2)
     {
-      /*
-       * temp1 = H + SHA512_SIGMA1(E) + SHA_Ch(E,F,G) + K[t] + W[t];
-       */
+#if 0 
+      temp1 = H + SHA512_SIGMA1(E) + SHA_Ch(E,F,G) + K[t] + W[t];
+#endif       
       SHA512_SIGMA1 (E, temp1);
       SHA512_ADD (H, temp1, temp2);
       SHA_Ch (E, F, G, temp3);
       SHA512_ADD (temp2, temp3, temp4);
       SHA512_ADD (&K[t2], &W[t2], temp5);
       SHA512_ADD (temp4, temp5, temp1);
-      /*
-       * temp2 = SHA512_SIGMA0(A) + SHA_Maj(A,B,C);
-       */
+#if 0    
+      temp2 = SHA512_SIGMA0(A) + SHA_Maj(A,B,C);
+#endif 
       SHA512_SIGMA0 (A, temp3);
       SHA_Maj (A, B, C, temp4);
       SHA512_ADD (temp3, temp4, temp2);


### PR DESCRIPTION
Fixing c4200 found on MSVC 2010 while updating Xbox/Xbox 360 port.