### PR TITLE
fix p_syntax_id_t initialize

### DIFF
--- a/lib/dcerpc.c
+++ b/lib/dcerpc.c
@@ -81,11 +81,11 @@ struct dcerpc_deferred_pointer {
  */
 
 p_syntax_id_t ndr32_syntax = {
-        {NDR32_UUID}, 2
+        {NDR32_UUID}, 2, 0
 };
 
 p_syntax_id_t ndr64_syntax = {
-        {NDR64_UUID}, 1
+        {NDR64_UUID}, 1, 0
 };
 
 struct dcerpc_context {


### PR DESCRIPTION
The following structures are defined.
```
typedef struct p_syntax_id {
        dcerpc_uuid_t uuid;
        uint16_t vers;
        uint16_t vers_minor;
} p_syntax_id_t;
```
p_syntax_id_t has three member variables.

The structure is initialized below, but one member variable is missing.
```
p_syntax_id_t ndr32_syntax = {
        {NDR32_UUID}, 2
};

p_syntax_id_t ndr64_syntax = {
        {NDR64_UUID}, 1
};
```

Such a change is required.
```
p_syntax_id_t ndr32_syntax = {
        {NDR32_UUID}, 2, 0
};

p_syntax_id_t ndr64_syntax = {
        {NDR64_UUID}, 1, 0
};
```