### PR TITLE
PS3: fix uninitialize addrinfo struct causing crash

### DIFF
--- a/lib/compat.c
+++ b/lib/compat.c
@@ -252,6 +252,7 @@ int smb2_getaddrinfo(const char *node, const char*service,
         } 
 
         *res = malloc(sizeof(struct addrinfo));
+        memset(*res, 0, sizeof(struct addrinfo));
 #endif
         (*res)->ai_family = AF_INET;
         (*res)->ai_addrlen = sizeof(struct sockaddr_in);


### PR DESCRIPTION
Fix crash caused by uninitialized addrinfo struct especially in for loop in socket.c that references ai->ai_next. This has been broken since commit 3cbcc5a32af2183fb28864be1bd7907325c0b81d
