### PR TITLE
Fix EAGAIN check in smb2_read_data

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -360,7 +360,7 @@ read_more_data:
                 if (err == WSAEINTR || err == WSAEWOULDBLOCK) {
 #else
                 int err = errno;
-                if (err == EINTR || err == EAGAIN) {
+                if (err == EINTR || err == EAGAIN || err == EWOULDBLOCK) {
 #endif
                         return 0;
                 }


### PR DESCRIPTION
GNU defines ``EAGAIN`` and ``EWOULDBLOCK`` as the same value but notes both values should be checked for portability.

This resolves a ``Read from socket failed`` issue introduced when building with non-GNU environments that define EAGAIN and EWOULDBLOCK as separate, distinct values.

As noted in the GNU libc documentation under [2.2 Error Codes](https://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Error-Codes.html).

> Portability Note: In many older Unix systems, this condition was indicated by ``EWOULDBLOCK``, which was a distinct error code different from ``EAGAIN``. To make your program portable, you should check for both codes and treat them the same.

This patch corrects the check in ``smb2_read_data`` that could fail under a ``read_more_data`` goto and a socket read that returns ``EWOULDBLOCK``.

Similar checks already appear in the ``libsmb2`` codebase.
https://github.com/sahlberg/libsmb2/blob/c88fe13cb7a3b67cc93db852c385c89c539a0016/lib/socket.c#L277