### PR TITLE
(Windows) Add missing fsync exports

### DIFF
--- a/lib/libsmb2.syms
+++ b/lib/libsmb2.syms
@@ -39,6 +39,8 @@ smb2_free_data
 smb2_free_pdu
 smb2_fstat
 smb2_fstat_async
+smb2_fsync
+smb2_fsync_async
 smb2_ftruncate
 smb2_ftruncate_async
 smb2_get_client_guid


### PR DESCRIPTION
This PR adds the following missing exports on Windows:
```
smb2_fsync
smb2_fsync_async
```