### PR TITLE
Fix pwrite offset encoding

### DIFF
--- a/lib/smb2-cmd-write.c
+++ b/lib/smb2-cmd-write.c
@@ -79,6 +79,7 @@ smb2_encode_write_request(struct smb2_context *smb2,
         smb2_set_uint16(iov, 0, SMB2_WRITE_REQUEST_SIZE);
         smb2_set_uint16(iov, 2, SMB2_HEADER_SIZE + 48);
         smb2_set_uint32(iov, 4, req->length);
+        smb2_set_uint64(iov, 8, req->offset);
         memcpy(iov->buf + 16, req->file_id, SMB2_FD_SIZE);
         smb2_set_uint32(iov, 32, req->channel);
         smb2_set_uint32(iov, 36, req->remaining_bytes);


### PR DESCRIPTION
This PR fixes an issue in write and pwrite functions, due to missing offset.

This is a critical issue in ftruncate, which I could not find the isssue yet.