### PR TITLE
Fix a memory leak.

### DIFF
--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -258,6 +258,12 @@ struct smb2_context {
         struct smb2_context *next;
 };
 
+/*
+ * Callback for freeing a payload.
+ */
+typedef void (*smb2_free_payload)(struct smb2_context *smb2, void *payload);
+
+
 #define SMB2_MAX_PDU_SIZE 16*1024*1024
 
 struct smb2_pdu {
@@ -274,6 +280,11 @@ struct smb2_pdu {
 
         /* pointer to the unmarshalled payload in a reply */
         void *payload;
+    
+        /* callback that frees the any additional memory allocated in the payload.
+         * Or null if no additional memory needs to be freed.
+         */
+        smb2_free_payload free_payload;
 
         /* For sending/receiving
          * out contains at least two vectors:

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -364,6 +364,10 @@ smb2_free_pdu(struct smb2_context *smb2, struct smb2_pdu *pdu)
         smb2_free_iovector(smb2, &pdu->out);
         smb2_free_iovector(smb2, &pdu->in);
 
+        if (pdu->free_payload != NULL) {
+            pdu->free_payload(smb2, pdu->payload);
+        }
+    
         free(pdu->payload);
         free(pdu->crypt);
         free(pdu);

--- a/lib/smb2-cmd-read.c
+++ b/lib/smb2-cmd-read.c
@@ -261,6 +261,17 @@ smb2_process_read_fixed(struct smb2_context *smb2,
         return rep->data_length;
 }
 
+static void free_read_reply(struct smb2_context *smb2, void * payload) {
+    if (payload == NULL) {
+        return;
+    }
+    
+    struct smb2_read_reply *rep = (struct smb2_read_reply*)payload;
+    if (rep->data_length != 0 && rep->data != NULL) {
+        free(rep->data);
+    }
+}
+
 int
 smb2_process_read_variable(struct smb2_context *smb2,
                         struct smb2_pdu *pdu)
@@ -270,6 +281,7 @@ smb2_process_read_variable(struct smb2_context *smb2,
 
         rep->data = malloc(rep->data_length);
         if (rep->data) {
+                pdu->free_payload = free_read_reply;
                 memcpy(rep->data, iov->buf, rep->data_length);
                 return 0;
         }


### PR DESCRIPTION
Memory allocated in file smb2-cmd-read.c and function smb2_process_read_variable is never deallocated. This PR fixes that issue. Since pdu stores a void* pointer to the payload it doesn't know how to deallocate it. I added a callback to struct smb2_pdu that frees the payload and is set in the smb2_process_read_variable function 