### PR TITLE
fix offsets in write pdu, dont leak dir name

### DIFF
--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -383,6 +383,18 @@ void smb2_set_user(struct smb2_context *smb2, const char *user);
 const char *smb2_get_user(struct smb2_context *smb2);
 
 /*
+ * Get the workstation associated with a context.
+ * returns NULL if none
+ */
+const char *smb2_get_workstation(struct smb2_context *smb2);
+
+/*
+ * Get the domain associated with a context.
+ * returns NULL if none
+ */
+const char *smb2_get_domain(struct smb2_context *smb2);
+
+/*
  * Set the password that we will try to authenticate as.
  * This function is only needed when libsmb2 is built --without-libkrb5
  */

--- a/lib/krb5-wrapper.h
+++ b/lib/krb5-wrapper.h
@@ -62,7 +62,6 @@ struct private_auth_data {
         uint32_t req_flags;
         gss_buffer_desc output_token;
         int get_proxy_cred;
-        int s4u2self;
         int use_spnego;
         char *g_server;
         krb5_context krb5_cctx;

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -3206,12 +3206,10 @@ smb2_query_directory_request_cb(struct smb2_server *server, struct smb2_context 
                         pdu = smb2_cmd_query_directory_reply_async(smb2, req, &rep, NULL, cb_data);
                 }
         }
+        if (req->name) {
+                smb2_free_data(smb2, discard_const(req->name));
+        }
         if (pdu != NULL) {
-                if (req->name) {
-                        /* this will get auto-free when context is closed
-                         * if we dont do it here, so not required */
-                        smb2_free_data(smb2, discard_const(req->name));
-                }
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3319,7 +3317,7 @@ smb2_general_client_request_cb(struct smb2_context *smb2, int status, void *comm
                 smb2_close_context(smb2);
                 return;
         }
-        if (status == SMB2_STATUS_CANCELLED) {
+        if (status == SMB2_STATUS_CANCELLED || status == SMB2_STATUS_SHUTDOWN) {
                 return;
         }
 

--- a/lib/smb2-cmd-write.c
+++ b/lib/smb2-cmd-write.c
@@ -91,7 +91,7 @@ smb2_encode_write_request(struct smb2_context *smb2,
                 if (smb2->passthrough) {
                         req->write_channel_info_offset =
                                 (SMB2_READ_REQUEST_SIZE & 0xfffffffe) + SMB2_HEADER_SIZE;
-                        smb2_set_uint16(iov, 44, req->write_channel_info_offset);
+                        smb2_set_uint16(iov, 40, req->write_channel_info_offset);
 
                         len = PAD_TO_64BIT(req->write_channel_info_length);
                         buf = malloc(len);
@@ -262,10 +262,11 @@ smb2_process_write_request_fixed(struct smb2_context *smb2,
         smb2_get_uint32(iov, 4, &req->length);
         smb2_get_uint64(iov, 8, &req->offset);
         memcpy(req->file_id, iov->buf + 16, SMB2_FD_SIZE);
-        smb2_get_uint32(iov, 24, &req->channel);
-        smb2_get_uint32(iov, 28, &req->remaining_bytes);
-        smb2_get_uint16(iov, 32, &req->write_channel_info_offset);
-        smb2_get_uint16(iov, 34, &req->write_channel_info_length);
+        smb2_get_uint32(iov, 32, &req->channel);
+        smb2_get_uint32(iov, 36, &req->remaining_bytes);
+        smb2_get_uint16(iov, 40, &req->write_channel_info_offset);
+        smb2_get_uint16(iov, 42, &req->write_channel_info_length);
+        smb2_get_uint32(iov, 44, &req->flags);
         req->buf = NULL;
 
         if (req->write_channel_info_length) {


### PR DESCRIPTION
Also, a bit if simplification in krb5 server cred acquisition.  It turns out getting a delegated cred is really all that's needed if you get one.

Also fixes crashes when client disconnects from server since cancel status was replaces with shutdown status in init.d