### PR TITLE
Allow use of non-default keytab for server service authentication

### DIFF
--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 #define LIBSMB2_SHARE_ENUM_V2 1
-        
+
 struct smb2_iovec {
         uint8_t *buf;
         size_t len;
@@ -1338,6 +1338,10 @@ struct smb2_server {
         /* saved from negotiate to be used in validate negotiate info */
         uint32_t capabilities;
         uint32_t security_mode;
+        /* for kerberos, credential context */
+        char keytab_path[256];
+        char error[128];
+        void *auth_data;
 };
 
 int smb2_bind_and_listen(const uint16_t port, const int max_connections, int *out_fd);

--- a/lib/krb5-wrapper.c
+++ b/lib/krb5-wrapper.c
@@ -836,6 +836,10 @@ krb5_renew_server_credentials(struct smb2_server *server)
         struct private_auth_data *auth_data = server->auth_data;
         int ret;
 
+        if (!auth_data || !auth_data->keytab) {
+                return 0;
+        }
+
         do { /* try */
                 if (!auth_data) {
                         ret = -1;
@@ -872,6 +876,13 @@ krb5_init_server_credentials(struct smb2_server *server, const char *keytab_path
         int ret = -1;
 
         server->error[0] = '\0';
+
+        /* without a key table path, there is no need for this as the default one will
+         * be used in gss_acquire_cred and the initial creds will have to be done via kinit
+         */
+        if (!server || !keytab_path || !keytab_path[0]) {
+                return 0;
+        }
 
         do { // try
                 auth_data = calloc(1, sizeof(struct private_auth_data));

--- a/lib/krb5-wrapper.h
+++ b/lib/krb5-wrapper.h
@@ -66,6 +66,9 @@ struct private_auth_data {
         char *g_server;
         krb5_context krb5_cctx;
         krb5_ccache krb5_Ccache;
+        krb5_principal principal;
+        krb5_keytab keytab;
+        krb5_creds server_cred;
 };
 
 void
@@ -97,7 +100,7 @@ krb5_session_request(struct smb2_context *smb2,
                      unsigned char *buf, int len);
 
 struct private_auth_data *
-krb5_init_server_cred(struct smb2_server *server,
+krb5_init_server_client_cred(struct smb2_server *server,
                struct smb2_context *smb2, const char *password);
 
 int
@@ -112,6 +115,15 @@ krb5_set_gss_error(struct smb2_context *smb2, char *func,
 
 int
 krb5_can_do_ntlmssp(void);
+
+int
+krb5_init_server_credentials(struct smb2_server *server, const char *keytab_path);
+
+int
+krb5_renew_server_credentials(struct smb2_server *server);
+
+void
+krb5_free_server_credentials(struct smb2_server *server);
 
 #ifdef __cplusplus
 }

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -4051,11 +4051,9 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
         }
 
 #if HAVE_LIBKRB5
-        if (server->keytab_path) {
-                err = krb5_init_server_credentials(server, server->keytab_path);
-                if (err) {
-                        return err;
-                }
+        err = krb5_init_server_credentials(server, server->keytab_path);
+        if (err) {
+                return err;
         }
 #endif
         err = smb2_bind_and_listen(server->port, max_connections, &server->fd);

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -2828,7 +2828,7 @@ smb2_decode_filenotifychangeinformation(
     uint32_t next_entry_offset)
 {
         uint32_t name_len;
-        
+
         smb2_get_uint32(vec, next_entry_offset+4, &fnc->action);
         smb2_get_uint32(vec, next_entry_offset+8, &name_len);
         fnc->name = smb2_utf16_to_utf8((uint16_t *)&vec->buf[next_entry_offset+12], name_len / 2);
@@ -2860,7 +2860,7 @@ struct notify_change_cb_data {
         // filter of SMB2_CHANGE_NOTIFY_FILE_NOTIFY_CHANGE_* flags
         uint16_t filter;
         // flags such as SMB2_CHANGE_NOTIFY_WATCH_TREE
-        uint32_t flags;      
+        uint32_t flags;
         // do a new notify_change request after each response if 1
         uint32_t loop;
         uint32_t status;
@@ -2897,7 +2897,7 @@ notify_change_cb(struct smb2_context *smb2, int status,
                 );
         }
         if (notify_change_data->loop) {
-                smb2_notify_change_filehandle_async(smb2, notify_change_data->fh, notify_change_data->flags, notify_change_data->filter, 
+                smb2_notify_change_filehandle_async(smb2, notify_change_data->fh, notify_change_data->flags, notify_change_data->filter,
                         notify_change_data->loop, notify_change_data->cb, notify_change_data->cb_data);
         } else {
                 smb2_close(smb2, notify_change_data->fh);
@@ -2907,7 +2907,7 @@ notify_change_cb(struct smb2_context *smb2, int status,
 
 int smb2_notify_change_filehandle_async(struct smb2_context *smb2, struct smb2fh *smb2_dir_fh, uint16_t flags, uint32_t filter, int loop,
                        smb2_command_cb cb, void *cb_data)
-{       
+{
         struct notify_change_cb_data *notify_change_cb_data;
         struct smb2_change_notify_request ch_req;
         struct smb2_pdu *pdu;
@@ -2948,7 +2948,7 @@ int smb2_notify_change_filehandle_async(struct smb2_context *smb2, struct smb2fh
 
 int smb2_notify_change_async(struct smb2_context *smb2, const char *path, uint16_t flags, uint32_t filter, int loop,
                        smb2_command_cb cb, void *cb_data)
-{       
+{
         struct smb2fh *fh;
 #ifdef O_DIRECTORY
         fh = smb2_open(smb2, path, O_DIRECTORY);
@@ -2956,7 +2956,7 @@ int smb2_notify_change_async(struct smb2_context *smb2, const char *path, uint16
         fh = smb2_open(smb2, path, 0);
 #endif
         if (fh == NULL) {
-		smb2_set_error(smb2, "smb2_open failed. %s\n", smb2_get_error(smb2));
+                smb2_set_error(smb2, "smb2_open failed. %s\n", smb2_get_error(smb2));
                 return -1;
         }
         return smb2_notify_change_filehandle_async(smb2, fh, flags, filter, loop, cb, cb_data);
@@ -3674,11 +3674,7 @@ smb2_session_setup_request_cb(struct smb2_context *smb2, int status, void *comma
 #ifdef HAVE_LIBKRB5
         else {
                 if (!c_data->auth_data) {
-                        /* note that for server, the auth creds really only need to be
-                         * setup once for all connections, but we do it each time to
-                         * simplify auth_data lifetime, perhaps TODO?
-                         */
-                        c_data->auth_data = krb5_init_server_cred(server, smb2, NULL);
+                        c_data->auth_data = krb5_init_server_client_cred(server, smb2, NULL);
                         if (!c_data->auth_data) {
                                 smb2_set_error(smb2, "can not init auth data %s", smb2_get_error(smb2));
                                 smb2_close_context(smb2);
@@ -4033,6 +4029,10 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
         struct timeval timeout;
         int err = -1;
         static const char *default_domain = "WORKGROUP";
+        time_t now;
+#if HAVE_LIBKRB5
+        static time_t credential_renewal_time = 0;
+#endif
 
         if (!server->max_transact_size) {
                 server->max_transact_size = 0x100000;
@@ -4049,6 +4049,15 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
                 strncpy(server->domain, default_domain,
                                MIN(sizeof(server->domain),strlen(default_domain) + 1));
         }
+
+#if HAVE_LIBKRB5
+        if (server->keytab_path) {
+                err = krb5_init_server_credentials(server, server->keytab_path);
+                if (err) {
+                        return err;
+                }
+        }
+#endif
         err = smb2_bind_and_listen(server->port, max_connections, &server->fd);
         if (err != 0) {
                 return err;
@@ -4094,7 +4103,7 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
                            );
 
                 if (ready > 0) {
-                        time_t t = time(NULL);
+                        now = time(NULL);
 
                         /* for each client context ready to read, process that context */
                         for (smb2 = smb2_active_contexts(); smb2; smb2 = smb2->next) {
@@ -4113,7 +4122,7 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
                                                 smb2_close_context(smb2);
                                         }
                                 }
-                                if (!SMB2_VALID_SOCKET(smb2->fd) && ((time(NULL) - t) > (smb2->timeout)))
+                                if (!SMB2_VALID_SOCKET(smb2->fd) && ((time(NULL) - now) > (smb2->timeout)))
                                 {
                                         smb2_set_error(smb2, "Timeout expired and no connection exists\n");
                                         smb2_close_context(smb2);
@@ -4169,6 +4178,16 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
                                 /* client connections are destroyed when they timeout or get disconnected */
                         }
                 }
+#if HAVE_LIBKRB5
+                /* renew kerberos credentials daily */
+                time(&now);
+
+                if (credential_renewal_time < now) {
+                        credential_renewal_time = now + 60*60*24;
+
+                        err = krb5_renew_server_credentials(server);
+                }
+#endif
         }
         while (err == 0);
 
@@ -4179,6 +4198,9 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
                 smb2 = smb2_active_contexts();
                 smb2_destroy_context(smb2);
         }
+#if HAVE_LIBKRB5
+        krb5_free_server_credentials(server);
+#endif
         return err;
 }
 


### PR DESCRIPTION
by specifying a key table file path, the kerberos credentials for the server service can be acquired without the need for a password or doing"kinit" in the shell and running as root to allow access to the krb5 default keytab

The programmatically does the equivalent of 

kinit -kt <keytab path> -c <memory-cache> cifs/<hostname>

getting initial credentials from the KDC using the key table

Then to acquire cred to accept an client connection, gss_acquire_cred_from is used with the keytab and cache path instead of the defaults.  Works great.

Also adds a daily renew of credentials to the server can run continuously in kerberos world

former behavior happens if no keytab path set in server context

Benefits
- no password needed to pass to or store in server
- no use of the default cache, so clients and other programs can kinit on the same machine without affecting the server
- no need to run as root user (to get access to krb5.keytab for initiator creds)
- no need to merge the key for the service in to the default keytab, can just use standalone

