### PR TITLE
Bdd/fix getinfo buffer overflow

### DIFF
--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -32,7 +32,7 @@ extern "C" {
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_ext.h>
 #endif /* __APPLE__ */
-#endif /* HAVE_LIBKRB5 */ 
+#endif /* HAVE_LIBKRB5 */
 
 #define MIN(a,b) (((a)<(b))?(a):(b))
 
@@ -341,7 +341,7 @@ struct smb2dir {
         int index;
 };
 
-        
+
 #define smb2_is_server(ctx) ((ctx)->owning_server != NULL)
 
 void smb2_set_nterror(struct smb2_context *smb2, int nterror,
@@ -554,6 +554,13 @@ int smb2_encode_file_network_open_info(struct smb2_context *smb2,
                                        struct smb2_file_network_open_info *fs,
                                        struct smb2_iovec *vec);
 
+int smb2_decode_file_normalized_name_info(struct smb2_context *smb2,
+                                          void *memctx,
+                                          struct smb2_file_name_info *fs,
+                                          struct smb2_iovec *vec);
+int smb2_encode_file_normalized_name_info(struct smb2_context *smb2,
+                                          struct smb2_file_name_info *fs,
+                                          struct smb2_iovec *vec);
 int smb2_decode_security_descriptor(struct smb2_context *smb2,
                                     void *memctx,
                                     struct smb2_security_descriptor *sd,

--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -642,6 +642,7 @@ void smb2_add_compound_pdu(struct smb2_context *smb2,
                            struct smb2_pdu *pdu, struct smb2_pdu *next_pdu);
 void smb2_free_pdu(struct smb2_context *smb2, struct smb2_pdu *pdu);
 void smb2_queue_pdu(struct smb2_context *smb2, struct smb2_pdu *pdu);
+void smb2_set_pdu_status(struct smb2_context *smb2, struct smb2_pdu *pdu, int status);
 int smb2_pdu_is_compound(struct smb2_context *smb2);
 
 /*

--- a/include/smb2/smb2-errors.h
+++ b/include/smb2/smb2-errors.h
@@ -544,4 +544,6 @@
 #define SMB2_STATUS_SERVER_UNAVAILABLE                 0xC0000466
 
 /* Warning codes */
-#define SMB2_STATUS_STOPPED_ON_SYMLINK  0x8000002d
+#define SMB2_STATUS_BUFFER_OVERFLOW                    0x80000005
+#define SMB2_STATUS_STOPPED_ON_SYMLINK                 0x8000002D
+

--- a/include/smb2/smb2.h
+++ b/include/smb2/smb2.h
@@ -634,6 +634,14 @@ struct smb2_file_position_info {
 };
 
 /*
+ * FILE_NAME_INFORMATION
+ */
+struct smb2_file_name_info {
+        uint32_t file_name_length;
+        const uint8_t *name;
+};
+
+/*
  * FILE_ALL_INFORMATION.
  */
 struct smb2_file_all_info {

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -8,6 +8,7 @@ libsmb2_la_CPPFLAGS = -I$(abs_top_srcdir)/include \
 
 libsmb2_la_SOURCES = \
 	aes.h \
+	aes_reference.c \
 	aes.c \
 	aes128ccm.h \
 	aes128ccm.c \

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -654,6 +654,12 @@ smb2_queue_pdu(struct smb2_context *smb2, struct smb2_pdu *pdu)
         smb2_add_to_outqueue(smb2, pdu);
 }
 
+void
+smb2_set_pdu_status(struct smb2_context *smb2, struct smb2_pdu *pdu, int status)
+{
+        pdu->header.status = status;
+}
+
 struct smb2_pdu *
 smb2_find_pdu(struct smb2_context *smb2,
               uint64_t message_id) {


### PR DESCRIPTION
The buffer-overflow-status (0x80000005) was not being handled or generated in query-info replies.  This fixes that

Aslo - fixes Linux build from Makefile. Not sure how CI/CD missed that?