### PR TITLE
re-sent pending pdu after credits is enough

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -458,6 +458,8 @@ read_more_data:
 
                 if (!smb2_is_server(smb2)) {
                         smb2->credits += smb2->hdr.credit_request_response;
+                        /* Got credit, recheck if there are pending pdu to be sent. */
+                        smb2_change_events(smb2, smb2->fd, smb2_which_events(smb2));
                 }
 
                 if (!smb2_is_server(smb2) && !(smb2->hdr.flags & SMB2_FLAGS_SERVER_TO_REDIR)) {


### PR DESCRIPTION
`smb2_queue_pdu` may not set POLLOUT events due to insufficient credits, resulting in the pdu not being sent to server in a timely manner, and even if there are no subsequent new pdu, the pending pdu will never be sent to server.

So we should recheck pending pdu after got response of server.