### PR TITLE
Bdd/aysnc reply flag

### DIFF
--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -174,6 +174,7 @@ struct smb2_context {
         int  tree_id_cur;
         uint64_t message_id;
         uint64_t session_id;
+        uint64_t async_id;
         uint8_t *session_key;
         uint8_t session_key_size;
 

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -3060,10 +3060,10 @@ smb2_create_request_cb(struct smb2_server *server, struct smb2_context *smb2, vo
                 pdu = smb2_cmd_error_reply_async(smb2,
                                 &err, SMB2_CREATE, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
-        if (req->name) {
-                smb2_free_data(smb2, discard_const(req->name));
-        }
         if (pdu) {
+                if (req->name) {
+                        smb2_free_data(smb2, discard_const(req->name));
+                }
                 smb2_queue_pdu(smb2, pdu);
         }
 }

--- a/lib/smb2-cmd-query-info.c
+++ b/lib/smb2-cmd-query-info.c
@@ -304,6 +304,7 @@ smb2_encode_query_info_reply(struct smb2_context *smb2,
                                 smb2_set_error(smb2, "No encoding for info_type/"
                                         "info_class %d/%d yet",
                                         req->info_type, req->file_info_class);
+                                iov->len = 0;
                         }
                 } else {
                         if (created_output_buffer_length > req->output_buffer_length) {


### PR DESCRIPTION
Three commits here for
- I had changed the create handler to free req->name unconditionally to fix a leak, but it causes a crash if a proxy handler queues a reply pdu which frees req before returning, so now I only free if not handled in the callback
- the filesystem info encoders were all returning 0, but they need to return the encoded length to work properly which the do after this change
- Testing with Windows Server 2022 showed that the real reply to a request that is handled async does have the ASYNC bit set in flags.  I was using that bit to *not* remove the request from the waiting-for-replies list used to correlate the reply to a request, but really I needed to use that bit + STATUS_PENDING in status.  Now if I get a pending status I set async bit in the request in the waiting-for-reply queue so that when the real reply is queud I can set the async bit in it as well.  The spec isn't really clear if that bit is required in the real reply, but I think doing what MS does is better than not.  Also, this invents an "async_id" counter in the smb2 context to use to set an actual async-id in the async header when created.  Before it was just the process-id + tree_id being used which is obviously not terribly helpful.  Finally, I also stash that id in the request in waiting-for-reply list so when the real reply gets queued I can put that same async id in it