### PR TITLE
proper encoding of multiple locks, add backup to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ config.log
 config.status
 config.sub
 configure
+config.guess~
+config.sub~
+configure~
+install-sh~
+
 depcomp
 install-sh
 m4/

--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -643,6 +643,8 @@ void smb2_add_compound_pdu(struct smb2_context *smb2,
 void smb2_free_pdu(struct smb2_context *smb2, struct smb2_pdu *pdu);
 void smb2_queue_pdu(struct smb2_context *smb2, struct smb2_pdu *pdu);
 void smb2_set_pdu_status(struct smb2_context *smb2, struct smb2_pdu *pdu, int status);
+void smb2_set_pdu_message_id(struct smb2_context *smb2, struct smb2_pdu *pdu, uint64_t message_id);
+uint64_t smb2_get_pdu_message_id(struct smb2_context *smb2, struct smb2_pdu *pdu);
 int smb2_pdu_is_compound(struct smb2_context *smb2);
 
 /*

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -4128,7 +4128,7 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
                                 }
                                 if (!SMB2_VALID_SOCKET(smb2->fd) && ((time(NULL) - now) > (smb2->timeout)))
                                 {
-                                        smb2_set_error(smb2, "Timeout expired and no connection exists\n");
+                                        smb2_set_error(smb2, "Timeout expired and no connection exists");
                                         smb2_close_context(smb2);
                                 }
                                 if (smb2->timeout) {
@@ -4159,6 +4159,7 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
                                         smb2->max_transact_size = server->max_transact_size;
                                         smb2->max_read_size     = server->max_read_size;
                                         smb2->max_write_size    = server->max_write_size;
+
                                         if (cb) {
                                                 cb(smb2, cb_data);
                                         }
@@ -4168,7 +4169,9 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
                                 }
                         }
 
-                        /* cull connection-less clients here, one per iteration (since active list changes on destroy)*/
+                        /* cull connection-less servers here (servers who's client has disconnected)
+                         * do only one per iteration since active list changes on destroy
+                         */
                         for (smb2 = smb2_active_contexts(); smb2; smb2 = smb2->next) {
                                 if (smb2_is_server(smb2)) {
                                         if (!SMB2_VALID_SOCKET(smb2_get_fd(smb2))) {

--- a/lib/smb2-cmd-lock.c
+++ b/lib/smb2-cmd-lock.c
@@ -102,7 +102,7 @@ smb2_encode_lock_request(struct smb2_context *smb2,
                 }
                 iov = smb2_add_iovector(smb2, &pdu->out, buf, len, free);
 
-                for (i = 0, offset = 0; i < req->lock_count; i++) {
+                for (i = 0, offset = 0; i < req->lock_count - 1; i++) {
                         smb2_set_uint64(iov, offset, elements->offset);
                         smb2_set_uint64(iov, offset + 8, elements->length);
                         smb2_set_uint32(iov, offset + 16, elements->flags);

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -302,14 +302,15 @@ smb2_write_to_socket(struct smb2_context *smb2)
                                  * PDUs as individual PDUs.
                                  */
                                 pdu->next_compound = NULL;
-                                smb2->credits -= pdu->header.credit_charge;
 
                                 if (!smb2_is_server(smb2)) {
+                                        smb2->credits -= pdu->header.credit_charge;
                                         /* queue requests we send to correlate replies with */
                                         SMB2_LIST_ADD_END(&smb2->waitqueue, pdu);
                                 }
                                 else {
-                                        smb2->credits += pdu->header.credit_request_response;
+                                        /* alway allow writing replies */
+                                        smb2->credits = 128;
                                         /* no longer need this reply we've sent */
                                         smb2_free_pdu(smb2, pdu);
                                 }
@@ -513,6 +514,8 @@ read_more_data:
                         if (pdu->header.command > SMB2_SESSION_SETUP) {
                                 pdu->header.command = smb2->hdr.command;
                         }
+                        pdu->header.credit_charge = smb2->hdr.credit_charge;
+                        pdu->header.credit_request_response = smb2->hdr.credit_request_response;
                 }
                 else {
                         if ((smb2->hdr.command != SMB2_OPLOCK_BREAK) ||

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -515,7 +515,8 @@ read_more_data:
                         }
                 }
                 else {
-                        if (smb2->hdr.command != SMB2_OPLOCK_BREAK) {
+                        if ((smb2->hdr.command != SMB2_OPLOCK_BREAK) ||
+                                        (smb2->hdr.message_id != 0xffffffffffffffffULL)) {
                                 if (smb2->pdu) {
                                         smb2_free_pdu(smb2, smb2->pdu);
                                         smb2->pdu = NULL;
@@ -527,7 +528,9 @@ read_more_data:
                                 }
                                 SMB2_LIST_REMOVE(&smb2->waitqueue, pdu);
                         } else {
-                                /* oplock and lease break notifications won't have a pdu */
+                                /* oplock and lease break notifications won't have a pdu so make one
+                                 * oplock replies (that are NOT notifications, i.e. have a valid message_id)
+                                 * are normal replies handled above */
                                 pdu = smb2->pdu;
                                 if (!pdu) {
                                         pdu = smb2->pdu = smb2_allocate_pdu(smb2, SMB2_OPLOCK_BREAK,


### PR DESCRIPTION
When a client acknowledges an oplock break a reply is expected, an the reply can be an error with cmd type OPLOCK_BREAK.  My handling of that in socket.c assumed anything with OPLOCK_BREAK was a notification not reply, so the request is never completed hanging the client.  This PR changes the condition to use message_id of the incoming data to determine if it is a notification (message_if = 0xffffffff_ffffffff ) or a reply (message_id != ....).

For encoding n locks, since one lock is encoded into the regular iovec, there are n-1 locks to be encoded into the extended iovec, but I was encoding n by mistake causing segv

Also added some fodder to .gitignore that gets generates on my Macbook from configure
