### PR TITLE
Bdd/use hdr msgi if no pdu

### DIFF
--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -2983,6 +2983,7 @@ smb2_logoff_request_cb(struct smb2_server *server, struct smb2_context *smb2, vo
                                 &err, SMB2_LOGOFF, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3009,6 +3010,7 @@ smb2_tree_connect_request_cb(struct smb2_server *server, struct smb2_context *sm
                                 &err, SMB2_TREE_CONNECT, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3033,6 +3035,7 @@ smb2_tree_disconnect_request_cb(struct smb2_server *server, struct smb2_context 
                                 &err, SMB2_TREE_DISCONNECT, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 
@@ -3064,6 +3067,7 @@ smb2_create_request_cb(struct smb2_server *server, struct smb2_context *smb2, vo
                 if (req->name) {
                         smb2_free_data(smb2, discard_const(req->name));
                 }
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3090,6 +3094,7 @@ smb2_close_request_cb(struct smb2_server *server, struct smb2_context *smb2, voi
                                 &err, SMB2_CLOSE, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3114,6 +3119,7 @@ smb2_flush_request_cb(struct smb2_server *server, struct smb2_context *smb2, voi
                                 &err, SMB2_FLUSH, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3140,6 +3146,7 @@ smb2_read_request_cb(struct smb2_server *server, struct smb2_context *smb2, void
                                 &err, SMB2_READ, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3166,6 +3173,7 @@ smb2_write_request_cb(struct smb2_server *server, struct smb2_context *smb2, voi
                                 &err, SMB2_WRITE, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3209,6 +3217,7 @@ smb2_oplock_break_request_cb(struct smb2_server *server, struct smb2_context *sm
                                 &err, SMB2_LOCK, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3233,6 +3242,7 @@ smb2_lock_request_cb(struct smb2_server *server, struct smb2_context *smb2, void
                                 &err, SMB2_LOCK, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3279,6 +3289,7 @@ smb2_ioctl_request_cb(struct smb2_server *server, struct smb2_context *smb2, voi
                 }
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3299,6 +3310,7 @@ smb2_cancel_request_cb(struct smb2_server *server, struct smb2_context *smb2, vo
                                 &err, SMB2_CANCEL, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3322,6 +3334,7 @@ smb2_echo_request_cb(struct smb2_server *server, struct smb2_context *smb2, void
                                 &err, SMB2_ECHO, SMB2_STATUS_NOT_IMPLEMENTED, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3362,6 +3375,7 @@ smb2_query_directory_request_cb(struct smb2_server *server, struct smb2_context 
                 smb2_free_data(smb2, discard_const(req->name));
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3389,6 +3403,7 @@ smb2_change_notify_request_cb(struct smb2_server *server, struct smb2_context *s
                 pdu = smb2_cmd_change_notify_reply_async(smb2, &rep, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3426,6 +3441,7 @@ smb2_query_info_request_cb(struct smb2_server *server, struct smb2_context *smb2
                 }
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3451,6 +3467,7 @@ smb2_set_info_request_cb(struct smb2_server *server, struct smb2_context *smb2, 
                 pdu = smb2_cmd_set_info_reply_async(smb2, req, NULL, cb_data);
         }
         if (pdu != NULL) {
+                smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                 smb2_queue_pdu(smb2, pdu);
         }
 }
@@ -3767,6 +3784,8 @@ smb2_session_setup_request_cb(struct smb2_context *smb2, int status, void *comma
                 smb2_close_context(smb2);
                 return;
         }
+
+        smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
         smb2_queue_pdu(smb2, pdu);
         smb3_update_preauth_hash(smb2, pdu->out.niov, &pdu->out.iov[0]);
 }
@@ -3794,6 +3813,9 @@ smb2_negotiate_request_cb(struct smb2_context *smb2, int status, void *command_d
                 /* context is being destroyed */
                 return;
         }
+
+        /* assume we can always reply */
+        smb2->credits = 128;
 
         /* negotiate highest version in request dialects */
         switch (smb2->version) {
@@ -3841,6 +3863,7 @@ smb2_negotiate_request_cb(struct smb2_context *smb2, int status, void *command_d
                         if (pdu == NULL) {
                                 return;
                         }
+                        smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
                         smb2_queue_pdu(smb2, pdu);
                         return;
                 }
@@ -3968,6 +3991,7 @@ smb2_negotiate_request_cb(struct smb2_context *smb2, int status, void *command_d
                 return;
         }
 
+        smb2_set_pdu_message_id(smb2, pdu, smb2->message_id);
         smb2_queue_pdu(smb2, pdu);
         smb3_update_preauth_hash(smb2, pdu->out.niov, &pdu->out.iov[0]);
 

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -698,7 +698,12 @@ smb2_set_pdu_message_id(struct smb2_context *smb2, struct smb2_pdu *pdu, uint64_
 uint64_t
 smb2_get_pdu_message_id(struct smb2_context *smb2, struct smb2_pdu *pdu)
 {
-        return pdu->header.message_id;
+        if (pdu) {
+                return pdu->header.message_id;
+        } else if (smb2) {
+                return smb2->hdr.message_id;
+        }
+        return 0;
 }
 
 struct smb2_pdu *

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -545,12 +545,12 @@ smb2_decode_header(struct smb2_context *smb2, struct smb2_iovec *iov,
                                 smb2_select_tree_id(smb2, hdr->sync.tree_id);
                                 break;
                         }
-
-                        if (smb2_is_server(smb2)) {
-                                /* remember message id to format reply */
-                                smb2->message_id = hdr->message_id;
-                        }
                 }
+        }
+        if (smb2_is_server(smb2)) {
+                /* remember message id to format a reply for this
+                 * request (or ack this notification) */
+                smb2->message_id = hdr->message_id;
         }
         smb2_get_uint64(iov, 40, &hdr->session_id);
         memcpy(&hdr->signature, iov->buf + 48, 16);

--- a/lib/smb2-cmd-flush.c
+++ b/lib/smb2-cmd-flush.c
@@ -192,6 +192,8 @@ smb2_process_flush_request_fixed(struct smb2_context *smb2,
                 smb2_set_error(smb2, "Failed to allocate flush request");
                 return -1;
         }
+
+        memcpy(req->file_id, &iov->buf[8], SMB2_FD_SIZE);
         pdu->payload = req;
         return 0;
 }

--- a/lib/smb2-cmd-lock.c
+++ b/lib/smb2-cmd-lock.c
@@ -55,7 +55,6 @@
 #include "libsmb2.h"
 #include "libsmb2-private.h"
 
-
 static int
 smb2_encode_lock_request(struct smb2_context *smb2,
                           struct smb2_pdu *pdu,
@@ -265,7 +264,7 @@ smb2_process_lock_request_fixed(struct smb2_context *smb2,
         }
 
         ptr = smb2_alloc_init(smb2,
-                        req->lock_count * SMB2_LOCK_ELEMENT_SIZE);
+                        req->lock_count * sizeof(struct smb2_lock_element));
         if (!ptr) {
                 smb2_set_error(smb2, "can not alloc lock buffer.");
                 pdu->payload = NULL;
@@ -280,8 +279,8 @@ smb2_process_lock_request_fixed(struct smb2_context *smb2,
         if (req->lock_count > 0) {
                 struct smb2_iovec vec;
 
-                vec.buf = iov->buf + 24;
-                vec.len = iov->len - 24;
+                vec.buf = iov->buf + SMB2_LOCK_ELEMENT_SIZE;
+                vec.len = iov->len - SMB2_LOCK_ELEMENT_SIZE;
                 smb2_parse_locks(smb2, &vec, 0, 1, ptr);
         }
         return SMB2_LOCK_ELEMENT_SIZE * (req->lock_count - 1);

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -508,10 +508,10 @@ read_more_data:
                                 pdu->header.sync.tree_id = smb2->hdr.sync.tree_id;
                         }
                         /* if the session is properly opened then we could get
-                         * any request from the client, so use the headers command
-                         * not the pdus command for the rest of input
+                         * any request from the client, so use the header's command
+                         * not the pdu's command for the rest of input
                          */
-                        if (pdu->header.command > SMB2_SESSION_SETUP) {
+                        if (smb2->hdr.command > SMB2_SESSION_SETUP) {
                                 pdu->header.command = smb2->hdr.command;
                         }
                         pdu->header.credit_charge = smb2->hdr.credit_charge;


### PR DESCRIPTION
In the server, the request handler doesnt have access to the pdu of the request so can't mine the message id from it, so it can get the message id of the last request using the context instead.   Having the id is required now since replies are correlated by id (as they always should have been)

Also, I now alloc properly for the lock elements.  It was just lucky that the struct size == wire size but that might not be true on all platforms/compilers
