### PR TITLE
Fix issue #404: smb2_timeval_to_win return type too small for 32bit time_t

### DIFF
--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -398,7 +398,7 @@ void smb2_win_to_timeval(uint64_t smb2_time, struct smb2_timeval *tv);
 /*
  * Convert unit timeval to a win timestamp
  */
-time_t smb2_timeval_to_win(struct smb2_timeval *tv);
+uint64_t smb2_timeval_to_win(struct smb2_timeval *tv);
 
 /*
  * set the context error string

--- a/lib/ntlmssp.c
+++ b/lib/ntlmssp.c
@@ -102,7 +102,7 @@ struct auth_data {
 
         int spnego_wrap;
         int is_authenticated;
-        time_t wintime;
+        uint64_t wintime;
         uint8_t exported_session_key[SMB2_KEY_SIZE];
 };
 
@@ -615,7 +615,7 @@ encode_ntlm_auth(struct smb2_context *smb2, time_t ti,
         unsigned int NTChallengeResponse_len = 0;
         unsigned char NTProofStr[16];
         unsigned char LMStr[16];
-        time_t t;
+        uint64_t t;
         struct smb2_timeval tv _U_;
         char *server_name_buf;
         uint32_t server_name_len;

--- a/lib/timestamps.c
+++ b/lib/timestamps.c
@@ -55,10 +55,10 @@
 #include <libsmb2.h>
 #include "libsmb2-private.h"
 
-time_t
+uint64_t
 smb2_timeval_to_win(struct smb2_timeval *tv)
 {
-        return (tv->tv_sec * 10000000) +
+        return ((uint64_t)tv->tv_sec * 10000000) +
                 116444736000000000 + tv->tv_usec * 10;
 }
 


### PR DESCRIPTION
On systems stuck with a 32bit time_t the smb2_timeval_to_win function doesn't return the right value. It gets truncated and then connecting to shares doesn't work, especially to a macosx machine.

This change fixes that issue.

Potentially the time_t in smb2_timeval should ALSO change to a hard 64bit value. But that's not necessarily in scope for this issue. It may need to be a signed variable too, like int64_t. As I've heard that time_t ends up being signed in some systems? Maybe?