### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/lib/compat.h
+++ b/lib/compat.h
@@ -604,6 +604,10 @@ struct sockaddr_storage {
 #define ENODATA ENOATTR
 #endif
 
+#ifndef ENOLINK
+#define ENOLINK ENOATTR
+#endif
+
 #endif /* PS4_PLATFORM */
 
 #ifdef __vita__


### PR DESCRIPTION
OpenBSD does not have the ENOLINK errno.