### PR TITLE
Include <errno.h> before compat.h

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -99,6 +99,8 @@
 #include <sys/socket.h>
 #endif
 
+#include <errno.h>
+
 #include "compat.h"
 
 #include "slist.h"


### PR DESCRIPTION
`compat.h` defines fallback definitions for errno constants and it does not include `<errno.h>` on its own; if `<errno.h>` is not already included then there are wrongly generated fallback definitions.

Apply the approach already in other sources, i.e. explicitly include `<errno.h>` before `compat.h`.