### PR TITLE
fix target info field offset for non-litle endian systems

### DIFF
--- a/lib/ntlmssp.c
+++ b/lib/ntlmssp.c
@@ -382,7 +382,7 @@ ntlm_decode_challenge_message(struct smb2_context *smb2, struct auth_data *auth_
 
                 if (inlen > 0 && inlen < len && (outoff + inlen) < alloc_len) {
                         /* back annotate target info field offset */
-                        u32 = htole16(outoff);
+                        u32 = htole32(outoff);
                         memcpy(&auth_data->ntlm_buf[44], &u32, 4);
 
                         /* transcode target info fields, appending our target-name */


### PR DESCRIPTION
Corrected the wrong size byteswap function being used when constructing the target info field offset - it only worked on little endian systems that have no-op "host to le" functions.