### PR TITLE
Handle return from writes

### DIFF
--- a/examples/smb2-cat-async.c
+++ b/examples/smb2-cat-async.c
@@ -85,7 +85,10 @@ void pr_cb(struct smb2_context *smb2, int status,
                 return;
         }
 
-        write(STDOUT_FILENO, buf, status);
+        if(write(STDOUT_FILENO, buf, status) < 0) {
+            printf("Failed to write to STDOUT\n");
+            exit(10);
+        }
 
         pos += status;
         if (smb2_pread_async(smb2, fh, buf, READ_SIZE, pos, pr_cb, fh) < 0) {

--- a/examples/smb2-cat-sync.c
+++ b/examples/smb2-cat-sync.c
@@ -89,14 +89,17 @@ int main(int argc, char *argv[])
                         rc = 1;
                         break;
                 }
-                write(STDOUT_FILENO, buf, count);
+                if (write(STDOUT_FILENO, buf, count) < 0) {
+                    printf("Failed to write to STDOUT\n");
+                    exit(10);
+                }
                 pos += count;
         };
-                
+
         smb2_close(smb2, fh);
         smb2_disconnect_share(smb2);
         smb2_destroy_url(url);
         smb2_destroy_context(smb2);
-        
+
 	return rc;
 }


### PR DESCRIPTION
examples/smb2-cat-async.c and examples/smb2-cat-sync.c had write()'s whose return values were not being caught, which was preventing make from compiling the examples.