### PR TITLE
Fix heap out-of-bounds read in smb2_decode_file_all_info()

### DIFF
--- a/lib/smb2-data-file-info.c
+++ b/lib/smb2-data-file-info.c
@@ -311,9 +311,15 @@ smb2_decode_file_all_info(struct smb2_context *smb2,
         smb2_get_uint64(vec, 80, &fs->current_byte_offset);
         smb2_get_uint32(vec, 88, &fs->mode);
         smb2_get_uint32(vec, 92, &fs->alignment_requirement);
-        smb2_get_uint32(vec, 96, &name_len);
+        if (smb2_get_uint32(vec, 96, &name_len)) {
+                return -1;
+        }
 
         if (name_len > 0) {
+                if (name_len > vec->len - 100) {
+                        /* truncate if the server supplied a short reply */
+                        name_len = (uint32_t)(vec->len - 100);
+                }
                 name = smb2_utf16_to_utf8((uint16_t *)(void *)&vec->buf[100], name_len / 2);
                 if (!name) {
                         return -1;


### PR DESCRIPTION
This fixes the heap out-of-bounds read I reported to Ronnie by email, and
incorporates his review suggestions (keep option 2a and also check the
`smb2_get_uint32()` return value).

## Problem

`smb2_decode_file_all_info()` reads the server-controlled FileNameLength
(`name_len`) from offset 96 of a `QUERY_INFO(FILE_ALL_INFORMATION)` reply and
passes it straight to `smb2_utf16_to_utf8()`, which reads `name_len` bytes
starting at offset 100. `name_len` was never bounded against the actual
received buffer length (`vec->len`), so a malicious or MITM'd SMB server can
make the client read far past the end of the `malloc()`'d receive buffer (heap
out-of-bounds read, CWE-125) on any ordinary stat/getattr. The sibling decoders
`smb2_decode_file_stream_info()` and `smb2_decode_file_normalized_name_info()`
already clamp `name_len`; this one did not.

## Fix

- Check the return value of the final `smb2_get_uint32(vec, 96, &name_len)`. It
  fails when the buffer is shorter than 100 bytes, which also guarantees
  `vec->len >= 100` afterwards, so the `vec->len - 100` subtraction below cannot
  underflow.
- Clamp `name_len` to the bytes left in the buffer before decoding, exactly as
  the two sibling decoders do.

## Verification

Built the decoder with AddressSanitizer. A reply with
`output_buffer_length = 104` and `FileNameLength = 0x00100000` (offset 96)
triggers a heap-buffer-overflow READ in `smb2_utf16_to_utf8()` before this
change and parses cleanly after it; a negative control with `FileNameLength = 4`
does not trigger ASAN either way.

## Follow-up

Happy to add a regression test — either a standalone decoder test under `tests/`
or a SCRAMBLA-based reproducer, whichever you prefer.
