### PR TITLE
notify_change_cb: don't dereference a NULL reply on error/cancel

### DIFF
--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -2917,6 +2917,21 @@ notify_change_cb(struct smb2_context *smb2, int status,
                                strerror(-status), smb2_get_error(smb2));
         }
 
+        if (status || rep == NULL) {
+                /* Error or cancellation -- e.g. smb2_destroy_context() flushing the pending
+                 * watch request with command_data == NULL. There is no reply to decode, so
+                 * signal the failure to the callback, do not re-arm, and free. Without this
+                 * the unconditional rep->output dereference below SEGVs whenever a watcher
+                 * is torn down with a notify request still outstanding. */
+                if (notify_change_data->cb) {
+                        notify_change_data->cb(smb2, status ? status : -EIO,
+                                               NULL, notify_change_data->cb_data);
+                }
+                free(fnc);
+                free(notify_change_data);
+                return;
+        }
+
         vec.buf = rep->output;
         vec.len = rep->output_buffer_length;
 


### PR DESCRIPTION
When a CHANGE_NOTIFY request is still outstanding and the context is torn down, smb2_destroy_context() flushes the pending PDU by invoking its callback with status != 0 and command_data == NULL. notify_change_cb() then does "rep = command_data; vec.buf = rep->output;" and dereferences NULL, crashing. The same path also re-arms the watch (loop) on a context that is being destroyed and leaks the freshly calloc'd fnc.

Bail out early when status is set or the reply is NULL: signal the failure to the user callback (with a NULL reply), do not re-arm, and free. This fixes a SEGV on every teardown of a long-lived (loop) CHANGE_NOTIFY watch.