### PR TITLE
Add SMB2 server-side copy (FSCTL_SRV_COPYCHUNK) support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES smb2-cat-async
             smb2-raw-stat-async
             smb2-raw-getsd-async
             smb2-readlink
+            smb2-server-side-copy-sync
             smb2-lsa-lookupsids
             smb2-lseek-sync
             smb2-share-enum

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -8,6 +8,7 @@ noinst_PROGRAMS = dcerpc smb2-cat-async smb2-cat-sync \
 	smb2-raw-getsd-async \
 	smb2-raw-stat-async \
 	smb2-readlink \
+	smb2-server-side-copy-sync \
 	smb2-lsa-lookupsids \
 	smb2-lseek-sync \
 	smb2-share-enum \
@@ -41,6 +42,7 @@ smb2_raw_fsstat_async_LDADD = $(COMMON_LIBS)
 smb2_raw_getsd_async_LDADD = $(COMMON_LIBS)
 smb2_raw_stat_async_LDADD = $(COMMON_LIBS)
 smb2_readlink_LDADD = $(COMMON_LIBS)
+smb2_server_side_copy_sync_LDADD = $(COMMON_LIBS)
 smb2_lsa_lookupsids_LDADD = $(COMMON_LIBS)
 smb2_lseek_sync_LDADD = $(COMMON_LIBS)
 smb2_share_enum_LDADD = $(COMMON_LIBS)

--- a/examples/smb2-server-side-copy-sync.c
+++ b/examples/smb2-server-side-copy-sync.c
@@ -1,0 +1,207 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/*
+   Copyright (C) 2026 Rida Shamasneh
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _GNU_SOURCE
+
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "smb2.h"
+#include "libsmb2.h"
+
+/*
+Ths example was tested with an SMB server of with following limits:
+  - max chunk size: 1 MiB
+  - max total request size: 16 MiB
+  - max chunk count: 256
+*/
+#define COPYCHUNK_SIZE (1024 * 1024)
+#define MAX_COPYCHUNKS_PER_REQUEST 16
+
+int usage(void)
+{
+        fprintf(stderr, "Usage:\n"
+                "smb2-server-side-copy-sync <source-url> <destination-url>\n\n"
+                "Both URLs must point to the same server/share.\n"
+                "URL format: "
+                "smb://[<domain;][<username>@]<host>[:<port>]/<share>/<path>\n");
+        exit(1);
+}
+
+static int same_or_null(const char *a, const char *b)
+{
+        if (a == NULL || b == NULL) {
+                return a == b;
+        }
+
+        return strcmp(a, b) == 0;
+}
+
+int main(int argc, char *argv[])
+{
+        struct smb2_context *smb2;
+        struct smb2_url *src_url;
+        struct smb2_url *dst_url;
+        struct smb2fh *srcfh;
+        struct smb2fh *dstfh;
+        struct smb2_stat_64 st;
+        struct smb2_srv_copychunk_resume_key resume_key;
+        struct smb2_srv_copychunk chunks[MAX_COPYCHUNKS_PER_REQUEST];
+        struct smb2_srv_copychunk_reply reply;
+        uint64_t copied = 0;
+        uint64_t remaining;
+        uint32_t batch_count;
+        uint32_t i;
+        int rc = 0;
+
+        if (argc < 3) {
+                usage();
+        }
+
+        smb2 = smb2_init_context();
+        if (smb2 == NULL) {
+                fprintf(stderr, "Failed to init context\n");
+                return 1;
+        }
+
+        src_url = smb2_parse_url(smb2, argv[1]);
+        if (src_url == NULL) {
+                fprintf(stderr, "Failed to parse source url: %s\n",
+                        smb2_get_error(smb2));
+                smb2_destroy_context(smb2);
+                return 1;
+        }
+
+        dst_url = smb2_parse_url(smb2, argv[2]);
+        if (dst_url == NULL) {
+                fprintf(stderr, "Failed to parse destination url: %s\n",
+                        smb2_get_error(smb2));
+                smb2_destroy_url(src_url);
+                smb2_destroy_context(smb2);
+                return 1;
+        }
+
+        if (!same_or_null(src_url->domain, dst_url->domain) ||
+            !same_or_null(src_url->server, dst_url->server) ||
+            !same_or_null(src_url->share, dst_url->share) ||
+            !same_or_null(src_url->user, dst_url->user)) {
+                fprintf(stderr, "Source and destination URLs must use the same domain, server, share, and user\n");
+                rc = 1;
+                goto out;
+        }
+
+        smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
+        if (smb2_connect_share(smb2, src_url->server, src_url->share, src_url->user) != 0) {
+                fprintf(stderr, "smb2_connect_share failed. %s\n",
+                        smb2_get_error(smb2));
+                rc = 10;
+                goto out;
+        }
+
+        srcfh = smb2_open(smb2, src_url->path, O_RDONLY);
+        if (srcfh == NULL) {
+                fprintf(stderr, "Failed to open source file. %s\n",
+                        smb2_get_error(smb2));
+                rc = 10;
+                goto out_disconnect;
+        }
+
+        if (smb2_fstat(smb2, srcfh, &st) < 0) {
+                fprintf(stderr, "smb2_fstat failed. %s\n", smb2_get_error(smb2));
+                rc = 10;
+                goto out_close_src;
+        }
+
+        dstfh = smb2_open(smb2, dst_url->path, O_RDWR | O_CREAT | O_TRUNC);
+        if (dstfh == NULL) {
+                fprintf(stderr, "Failed to open destination file. %s\n",
+                        smb2_get_error(smb2));
+                rc = 10;
+                goto out_close_src;
+        }
+
+        if (smb2_request_resume_key(smb2, srcfh, &resume_key) < 0) {
+                fprintf(stderr, "smb2_request_resume_key failed. %s\n",
+                        smb2_get_error(smb2));
+                rc = 10;
+                goto out_close_dst;
+        }
+
+        if (st.smb2_size == 0) {
+                printf("Copied 0 bytes\n");
+                goto out_close_dst;
+        }
+
+        remaining = st.smb2_size;
+        while (remaining > 0) {
+                uint64_t batch_offset = copied;
+
+                memset(chunks, 0, sizeof(chunks));
+                memset(&reply, 0, sizeof(reply));
+
+                batch_count = 0;
+                for (i = 0;
+                     i < MAX_COPYCHUNKS_PER_REQUEST && remaining > 0;
+                     i++) {
+                        uint32_t chunk_size = COPYCHUNK_SIZE;
+
+                        if (remaining < COPYCHUNK_SIZE) {
+                                chunk_size = (uint32_t)remaining;
+                        }
+
+                        chunks[i].source_offset = copied;
+                        chunks[i].target_offset = copied;
+                        chunks[i].length = chunk_size;
+
+                        copied += chunk_size;
+                        remaining -= chunk_size;
+                        batch_count++;
+                }
+
+                if (smb2_copychunk(smb2,
+                                   SMB2_FSCTL_SRV_COPYCHUNK_WRITE,
+                                   &resume_key, dstfh, chunks,
+                                   batch_count, &reply) < 0) {
+                        fprintf(stderr,
+                                "smb2_copychunk failed at offset %" PRIu64 ". %s\n",
+                                batch_offset, smb2_get_error(smb2));
+                        rc = 10;
+                        goto out_close_dst;
+                }
+        }
+
+        printf("Copied %" PRIu64 " bytes\n", st.smb2_size);
+        printf("Last request chunks written:%" PRIu32 "\n",
+               reply.chunks_written);
+        printf("Last request chunk bytes written:%" PRIu32 "\n",
+               reply.chunk_bytes_written);
+        printf("Last request total bytes written:%" PRIu32 "\n",
+               reply.total_bytes_written);
+
+out_close_dst:
+        smb2_close(smb2, dstfh);
+out_close_src:
+        smb2_close(smb2, srcfh);
+out_disconnect:
+        smb2_disconnect_share(smb2);
+out:
+        smb2_destroy_url(dst_url);
+        smb2_destroy_url(src_url);
+        smb2_destroy_context(smb2);
+
+        return rc;
+}

--- a/include/libsmb2-private.h
+++ b/include/libsmb2-private.h
@@ -327,6 +327,12 @@ struct smb2_pdu {
         uint8_t info_type;
         uint8_t file_info_class;
 
+        /* Data we need to retain between request/reply for IOCTL, since
+         * some ctl codes report errors using the IOCTL reply format
+         * instead of the generic SMB2 error format.
+         */
+        uint32_t ctl_code;
+
         /* For encrypted PDUs */
         uint8_t seal:1;
         uint32_t crypt_len;
@@ -518,6 +524,7 @@ int smb2_process_ioctl_request_fixed(struct smb2_context *smb2,
                              struct smb2_pdu *pdu);
 int smb2_process_ioctl_request_variable(struct smb2_context *smb2,
                                 struct smb2_pdu *pdu);
+int smb2_ioctl_status_uses_reply_format(uint32_t ctl_code, uint32_t status);
 
 int smb2_decode_file_basic_info(struct smb2_context *smb2,
                                 void *memctx,

--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -1238,6 +1238,96 @@ int smb2_readlink_async(struct smb2_context *smb2, const char *path,
 int smb2_readlink(struct smb2_context *smb2, const char *path, char *buf, uint32_t bufsiz);
 
 /*
+ * SERVER-SIDE COPY
+ */
+/*
+ * Async request-resume-key.
+ *
+ * Returns
+ *  0     : The operation was initiated. The resume key will be reported
+ *          through the callback function.
+ * -errno : There was an error. The callback function will not be invoked.
+ *
+ * When the callback is invoked, status indicates the result:
+ *      0 : Success. Command_data is struct smb2_srv_copychunk_resume_key *.
+ *          This structure must be freed using smb2_free_data().
+ * -errno : An error occurred.
+ */
+int smb2_request_resume_key_async(struct smb2_context *smb2, struct smb2fh *fh,
+                                  smb2_command_cb cb, void *cb_data);
+
+/*
+ * Sync request-resume-key()
+ */
+int smb2_request_resume_key(struct smb2_context *smb2, struct smb2fh *fh,
+                            struct smb2_srv_copychunk_resume_key *resume_key);
+
+/*
+ * Async copychunk.
+ *
+ * Returns
+ *  0     : The operation was initiated. The copy result will be reported
+ *          through the callback function.
+ * -errno : There was an error. The callback function will not be invoked.
+ *
+ * When the callback is invoked, status indicates the result:
+ *      0 : Success. Command_data is struct smb2_srv_copychunk_reply *.
+ *          This structure must be freed using smb2_free_data().
+ * -errno : An error occurred. For server replies that include copy limits,
+ *          command_data may still be struct smb2_srv_copychunk_reply * and
+ *          must be freed using smb2_free_data().
+ */
+int smb2_copychunk_async(struct smb2_context *smb2,
+                         uint32_t ctl_code,
+                         const struct smb2_srv_copychunk_resume_key *resume_key,
+                         struct smb2fh *dstfh,
+                         const struct smb2_srv_copychunk *chunks,
+                         uint32_t chunk_count,
+                         smb2_command_cb cb, void *cb_data);
+
+/*
+ * Sync copychunk(). If the server returns copy-limit information together
+ * with an error status, reply is populated before the error is returned.
+ */
+int smb2_copychunk(struct smb2_context *smb2,
+                   uint32_t ctl_code,
+                   const struct smb2_srv_copychunk_resume_key *resume_key,
+                   struct smb2fh *dstfh,
+                   const struct smb2_srv_copychunk *chunks,
+                   uint32_t chunk_count,
+                   struct smb2_srv_copychunk_reply *reply);
+
+/*
+ * Async server-side copy helper. This requests a resume key for srcfh and
+ * issues a copychunk request to dstfh using the provided chunk array.
+ *
+ * When the callback is invoked, status indicates the result:
+ *      0 : Success. Command_data is struct smb2_srv_copychunk_reply *.
+ *          This structure must be freed using smb2_free_data().
+ * -errno : An error occurred. For server replies that include copy limits,
+ *          command_data may still be struct smb2_srv_copychunk_reply * and
+ *          must be freed using smb2_free_data().
+ */
+int smb2_server_side_copy_async(struct smb2_context *smb2,
+                                uint32_t ctl_code,
+                                struct smb2fh *srcfh, struct smb2fh *dstfh,
+                                const struct smb2_srv_copychunk *chunks,
+                                uint32_t chunk_count,
+                                smb2_command_cb cb, void *cb_data);
+
+/*
+ * Sync server-side copy helper. If the server returns copy-limit information
+ * together with an error status, reply is populated before the error is
+ * returned.
+ */
+int smb2_server_side_copy(struct smb2_context *smb2,
+                          uint32_t ctl_code,
+                          struct smb2fh *srcfh, struct smb2fh *dstfh,
+                          const struct smb2_srv_copychunk *chunks,
+                          uint32_t chunk_count,
+                          struct smb2_srv_copychunk_reply *reply);
+
+/*
  * Async echo()
  *
  * Returns

--- a/include/smb2/smb2.h
+++ b/include/smb2/smb2.h
@@ -347,6 +347,25 @@ typedef uint8_t smb2_file_id[SMB2_FD_SIZE];
 #define SMB2_LEASE_KEY_SIZE 16
 typedef uint8_t smb2_lease_key[SMB2_LEASE_KEY_SIZE];
 
+#define SMB2_SRV_COPYCHUNK_RESUME_KEY_SIZE 24
+
+struct smb2_srv_copychunk_resume_key {
+        uint8_t resume_key[SMB2_SRV_COPYCHUNK_RESUME_KEY_SIZE];
+};
+
+struct smb2_srv_copychunk {
+        uint64_t source_offset;
+        uint64_t target_offset;
+        uint32_t length;
+        uint32_t reserved;
+};
+
+struct smb2_srv_copychunk_reply {
+        uint32_t chunks_written;
+        uint32_t chunk_bytes_written;
+        uint32_t total_bytes_written;
+};
+
 struct smb2fh;
 smb2_file_id *smb2_get_file_id(struct smb2fh *fh);
 

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -2637,6 +2637,326 @@ smb2_readlink_async(struct smb2_context *smb2, const char *path,
         return 0;
 }
 
+struct smb2_ioctl_cb_data {
+        smb2_command_cb cb;
+        void *cb_data;
+        uint8_t *input;
+        uint32_t ctl_code;
+};
+
+static void
+smb2_ioctl_output_cb(struct smb2_context *smb2, int status,
+                     void *command_data, void *private_data)
+{
+        struct smb2_ioctl_cb_data *ioctl_data = private_data;
+        void *output = NULL;
+
+        if (status != SMB2_STATUS_SUCCESS) {
+                smb2_set_nterror(smb2, status, "%s", nterror_to_str(status));
+        }
+
+        /*
+         * command_data is only a valid struct smb2_ioctl_reply* when the
+         * reply used the IOCTL reply format. On success that is always the
+         * case; on error it is only true for the ctl codes/statuses that
+         * smb2_ioctl_status_uses_reply_format() recognizes (see
+         * smb2_is_error_response() in pdu.c, which decides the same thing
+         * when picking how to decode the reply). Any other error reply is
+         * struct smb2_error_reply* and must not be read as an ioctl reply.
+         */
+        if (status == SMB2_STATUS_SUCCESS ||
+            smb2_ioctl_status_uses_reply_format(ioctl_data->ctl_code, status)) {
+                struct smb2_ioctl_reply *rep = command_data;
+
+                if (rep != NULL) {
+                        output = rep->output;
+                }
+        }
+
+        ioctl_data->cb(smb2, -nterror_to_errno(status), output,
+                       ioctl_data->cb_data);
+        free(ioctl_data->input);
+        free(ioctl_data);
+}
+
+static int
+smb2_encode_copychunk_input(struct smb2_context *smb2,
+                            const struct smb2_srv_copychunk_resume_key *resume_key,
+                            const struct smb2_srv_copychunk *chunks,
+                            uint32_t chunk_count,
+                            uint8_t **input,
+                            uint32_t *input_count)
+{
+        struct smb2_iovec iov;
+        uint32_t i;
+
+        if (resume_key == NULL) {
+                smb2_set_error(smb2, "Resume key was NULL");
+                return -EINVAL;
+        }
+        if (chunk_count == 0) {
+                smb2_set_error(smb2, "Chunk count must be non-zero");
+                return -EINVAL;
+        }
+        if (chunks == NULL) {
+                smb2_set_error(smb2, "Chunk array was NULL");
+                return -EINVAL;
+        }
+        if (chunk_count > ((UINT32_MAX - 32) / 24)) {
+                smb2_set_error(smb2, "Chunk count too large");
+                return -EINVAL;
+        }
+
+        *input_count = 32 + (chunk_count * 24);
+        *input = calloc(*input_count, sizeof(uint8_t));
+        if (*input == NULL) {
+                smb2_set_error(smb2, "Failed to allocate copychunk input");
+                return -ENOMEM;
+        }
+
+        memset(&iov, 0, sizeof(iov));
+        iov.buf = *input;
+        iov.len = *input_count;
+
+        memcpy(iov.buf, resume_key->resume_key,
+               SMB2_SRV_COPYCHUNK_RESUME_KEY_SIZE);
+        smb2_set_uint32(&iov, 24, chunk_count);
+
+        for (i = 0; i < chunk_count; i++) {
+                uint32_t offset = 32 + (i * 24);
+
+                smb2_set_uint64(&iov, offset + 0, chunks[i].source_offset);
+                smb2_set_uint64(&iov, offset + 8, chunks[i].target_offset);
+                smb2_set_uint32(&iov, offset + 16, chunks[i].length);
+                smb2_set_uint32(&iov, offset + 20, chunks[i].reserved);
+        }
+
+        return 0;
+}
+
+static int
+smb2_copychunk_submit_async(struct smb2_context *smb2,
+                            uint32_t ctl_code,
+                            const struct smb2_srv_copychunk_resume_key *resume_key,
+                            struct smb2fh *dstfh,
+                            const struct smb2_srv_copychunk *chunks,
+                            uint32_t chunk_count,
+                            smb2_command_cb cb, void *cb_data)
+{
+        struct smb2_ioctl_cb_data *ioctl_data;
+        struct smb2_ioctl_request req;
+        struct smb2_pdu *pdu;
+        uint32_t input_count;
+        int ret;
+
+        if (smb2 == NULL) {
+                return -EINVAL;
+        }
+        if (dstfh == NULL) {
+                smb2_set_error(smb2, "Destination file handle was NULL");
+                return -EINVAL;
+        }
+        if (ctl_code != SMB2_FSCTL_SRV_COPYCHUNK &&
+            ctl_code != SMB2_FSCTL_SRV_COPYCHUNK_WRITE) {
+                smb2_set_error(smb2, "Invalid copychunk ctl_code: 0x%08x",
+                               ctl_code);
+                return -EINVAL;
+        }
+
+        ioctl_data = calloc(1, sizeof(struct smb2_ioctl_cb_data));
+        if (ioctl_data == NULL) {
+                smb2_set_error(smb2, "Failed to allocate ioctl_data");
+                return -ENOMEM;
+        }
+
+        ret = smb2_encode_copychunk_input(smb2, resume_key, chunks,
+                                          chunk_count, &ioctl_data->input,
+                                          &input_count);
+        if (ret != 0) {
+                free(ioctl_data);
+                return ret;
+        }
+
+        ioctl_data->cb = cb;
+        ioctl_data->cb_data = cb_data;
+        ioctl_data->ctl_code = ctl_code;
+
+        memset(&req, 0, sizeof(req));
+        req.ctl_code = ctl_code;
+        memcpy(req.file_id, dstfh->file_id, SMB2_FD_SIZE);
+        req.input_count = input_count;
+        req.input = ioctl_data->input;
+        req.flags = SMB2_0_IOCTL_IS_FSCTL;
+
+        pdu = smb2_cmd_ioctl_async(smb2, &req, smb2_ioctl_output_cb,
+                                   ioctl_data);
+        if (pdu == NULL) {
+                free(ioctl_data->input);
+                free(ioctl_data);
+                return -EINVAL;
+        }
+        smb2_queue_pdu(smb2, pdu);
+
+        return 0;
+}
+
+int
+smb2_request_resume_key_async(struct smb2_context *smb2, struct smb2fh *fh,
+                              smb2_command_cb cb, void *cb_data)
+{
+        struct smb2_ioctl_cb_data *ioctl_data;
+        struct smb2_ioctl_request req;
+        struct smb2_pdu *pdu;
+
+        if (smb2 == NULL) {
+                return -EINVAL;
+        }
+        if (fh == NULL) {
+                smb2_set_error(smb2, "File handle was NULL");
+                return -EINVAL;
+        }
+
+        ioctl_data = calloc(1, sizeof(struct smb2_ioctl_cb_data));
+        if (ioctl_data == NULL) {
+                smb2_set_error(smb2, "Failed to allocate ioctl_data");
+                return -ENOMEM;
+        }
+        ioctl_data->cb = cb;
+        ioctl_data->cb_data = cb_data;
+        ioctl_data->ctl_code = SMB2_FSCTL_SRV_REQUEST_RESUME_KEY;
+
+        memset(&req, 0, sizeof(req));
+        req.ctl_code = SMB2_FSCTL_SRV_REQUEST_RESUME_KEY;
+        memcpy(req.file_id, fh->file_id, SMB2_FD_SIZE);
+        req.flags = SMB2_0_IOCTL_IS_FSCTL;
+
+        pdu = smb2_cmd_ioctl_async(smb2, &req, smb2_ioctl_output_cb,
+                                   ioctl_data);
+        if (pdu == NULL) {
+                free(ioctl_data);
+                return -EINVAL;
+        }
+        smb2_queue_pdu(smb2, pdu);
+
+        return 0;
+}
+
+int
+smb2_copychunk_async(struct smb2_context *smb2,
+                     uint32_t ctl_code,
+                     const struct smb2_srv_copychunk_resume_key *resume_key,
+                     struct smb2fh *dstfh,
+                     const struct smb2_srv_copychunk *chunks,
+                     uint32_t chunk_count,
+                     smb2_command_cb cb, void *cb_data)
+{
+        return smb2_copychunk_submit_async(smb2, ctl_code, resume_key, dstfh,
+                                           chunks, chunk_count, cb, cb_data);
+}
+
+struct smb2_server_side_copy_data {
+        smb2_command_cb cb;
+        void *cb_data;
+        struct smb2fh *dstfh;
+        uint32_t ctl_code;
+        uint32_t chunk_count;
+        struct smb2_srv_copychunk *chunks;
+};
+
+static void
+smb2_server_side_copy_resume_key_cb(struct smb2_context *smb2, int status,
+                                    void *command_data, void *private_data)
+{
+        struct smb2_server_side_copy_data *copy_data = private_data;
+        int ret;
+
+        if (status != 0) {
+                copy_data->cb(smb2, status, NULL, copy_data->cb_data);
+                free(copy_data->chunks);
+                free(copy_data);
+                return;
+        }
+
+        ret = smb2_copychunk_submit_async(smb2, copy_data->ctl_code,
+                                          command_data, copy_data->dstfh,
+                                          copy_data->chunks,
+                                          copy_data->chunk_count,
+                                          copy_data->cb,
+                                          copy_data->cb_data);
+        smb2_free_data(smb2, command_data);
+        if (ret != 0) {
+                copy_data->cb(smb2, ret, NULL, copy_data->cb_data);
+        }
+        free(copy_data->chunks);
+        free(copy_data);
+}
+
+int
+smb2_server_side_copy_async(struct smb2_context *smb2,
+                            uint32_t ctl_code,
+                            struct smb2fh *srcfh, struct smb2fh *dstfh,
+                            const struct smb2_srv_copychunk *chunks,
+                            uint32_t chunk_count,
+                            smb2_command_cb cb, void *cb_data)
+{
+        struct smb2_server_side_copy_data *copy_data;
+        int ret;
+
+        if (smb2 == NULL) {
+                return -EINVAL;
+        }
+        if (srcfh == NULL || dstfh == NULL) {
+                smb2_set_error(smb2, "File handle was NULL");
+                return -EINVAL;
+        }
+        if (chunk_count == 0) {
+                smb2_set_error(smb2, "Chunk count must be non-zero");
+                return -EINVAL;
+        }
+        if (chunks == NULL) {
+                smb2_set_error(smb2, "Chunk array was NULL");
+                return -EINVAL;
+        }
+        if (ctl_code != SMB2_FSCTL_SRV_COPYCHUNK &&
+            ctl_code != SMB2_FSCTL_SRV_COPYCHUNK_WRITE) {
+                smb2_set_error(smb2, "Invalid copychunk ctl_code: 0x%08x",
+                               ctl_code);
+                return -EINVAL;
+        }
+
+        copy_data = calloc(1, sizeof(struct smb2_server_side_copy_data));
+        if (copy_data == NULL) {
+                smb2_set_error(smb2, "Failed to allocate copy_data");
+                return -ENOMEM;
+        }
+
+        copy_data->chunks = calloc(chunk_count,
+                                   sizeof(struct smb2_srv_copychunk));
+        if (copy_data->chunks == NULL) {
+                free(copy_data);
+                smb2_set_error(smb2, "Failed to allocate chunk copy");
+                return -ENOMEM;
+        }
+
+        memcpy(copy_data->chunks, chunks,
+               chunk_count * sizeof(struct smb2_srv_copychunk));
+        copy_data->cb = cb;
+        copy_data->cb_data = cb_data;
+        copy_data->dstfh = dstfh;
+        copy_data->ctl_code = ctl_code;
+        copy_data->chunk_count = chunk_count;
+
+        ret = smb2_request_resume_key_async(smb2, srcfh,
+                                            smb2_server_side_copy_resume_key_cb,
+                                            copy_data);
+        if (ret != 0) {
+                free(copy_data->chunks);
+                free(copy_data);
+        }
+
+        return ret;
+}
+
 struct disconnect_data {
         smb2_command_cb cb;
         void *cb_data;
@@ -4289,4 +4609,3 @@ int smb2_serve_port(struct smb2_server *server, const int max_connections, smb2_
 #endif
         return err;
 }
-

--- a/lib/libsmb2.syms
+++ b/lib/libsmb2.syms
@@ -92,6 +92,8 @@ smb2_pread
 smb2_pread_async
 smb2_pwrite
 smb2_pwrite_async
+smb2_copychunk
+smb2_copychunk_async
 smb2_queue_pdu
 smb2_read
 smb2_read_async
@@ -100,6 +102,8 @@ smb2_register_error_callback
 smb2_rewinddir
 smb2_readlink
 smb2_readlink_async
+smb2_request_resume_key
+smb2_request_resume_key_async
 smb2_rmdir
 smb2_rmdir_async
 smb2_lseek
@@ -127,6 +131,8 @@ smb2_stat
 smb2_stat_async
 smb2_statvfs
 smb2_statvfs_async
+smb2_server_side_copy
+smb2_server_side_copy_async
 smb2_telldir
 smb2_timeval_to_win
 smb2_truncate

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -779,6 +779,11 @@ smb2_find_pdu(struct smb2_context *smb2,
 static int
 smb2_is_error_response(struct smb2_context *smb2,
                        struct smb2_pdu *pdu) {
+        if (pdu->header.command == SMB2_IOCTL &&
+            smb2_ioctl_status_uses_reply_format(pdu->ctl_code,
+                                                smb2->hdr.status)) {
+                return 0;
+        }
         if ((smb2->hdr.status & SMB2_STATUS_SEVERITY_MASK) ==
             SMB2_STATUS_SEVERITY_ERROR) {
                 switch (smb2->hdr.status) {

--- a/lib/smb2-cmd-ioctl.c
+++ b/lib/smb2-cmd-ioctl.c
@@ -55,6 +55,25 @@
 #include "libsmb2.h"
 #include "libsmb2-private.h"
 
+/*
+ * Some ctl codes report certain errors using the normal IOCTL reply
+ * format (struct smb2_ioctl_reply, with an output buffer) instead of the
+ * generic SMB2 error format. FSCTL_SRV_COPYCHUNK/_WRITE do this for
+ * STATUS_INVALID_PARAMETER, using the output buffer to carry a
+ * SRV_COPYCHUNK_RESPONSE with the server's copy limits.
+ */
+int
+smb2_ioctl_status_uses_reply_format(uint32_t ctl_code, uint32_t status)
+{
+        switch (ctl_code) {
+        case SMB2_FSCTL_SRV_COPYCHUNK:
+        case SMB2_FSCTL_SRV_COPYCHUNK_WRITE:
+                return status == SMB2_STATUS_INVALID_PARAMETER;
+        default:
+                return 0;
+        }
+}
+
 static int
 smb2_encode_ioctl_request(struct smb2_context *smb2,
                           struct smb2_pdu *pdu,
@@ -108,6 +127,7 @@ smb2_cmd_ioctl_async(struct smb2_context *smb2,
         if (pdu == NULL) {
                 return NULL;
         }
+        pdu->ctl_code = req->ctl_code;
 
         if (smb2_encode_ioctl_request(smb2, pdu, req)) {
                 smb2_free_pdu(smb2, pdu);
@@ -265,7 +285,7 @@ smb2_process_ioctl_fixed(struct smb2_context *smb2,
                 return -1;
         }
 
-        rep = malloc(sizeof(*rep));
+        rep = calloc(1, sizeof(*rep));
         if (rep == NULL) {
                 smb2_set_error(smb2, "Failed to allocate ioctl reply");
                 return -1;
@@ -327,6 +347,37 @@ smb2_process_ioctl_variable(struct smb2_context *smb2,
                                        smb2_get_error(smb2));
                         return -1;
                 }
+                break;
+        case SMB2_FSCTL_SRV_REQUEST_RESUME_KEY:
+                if (rep->output_count < SMB2_SRV_COPYCHUNK_RESUME_KEY_SIZE) {
+                        smb2_set_error(smb2, "Resume key reply too short");
+                        return -1;
+                }
+                ptr = smb2_alloc_init(smb2,
+                                      sizeof(struct smb2_srv_copychunk_resume_key));
+                if (ptr == NULL) {
+                        return -ENOMEM;
+                }
+                memcpy(((struct smb2_srv_copychunk_resume_key *)ptr)->resume_key,
+                       vec.buf, SMB2_SRV_COPYCHUNK_RESUME_KEY_SIZE);
+                break;
+        case SMB2_FSCTL_SRV_COPYCHUNK:
+        case SMB2_FSCTL_SRV_COPYCHUNK_WRITE:
+                if (rep->output_count < 12) {
+                        smb2_set_error(smb2, "Copychunk reply too short");
+                        return -1;
+                }
+                ptr = smb2_alloc_init(smb2,
+                                      sizeof(struct smb2_srv_copychunk_reply));
+                if (ptr == NULL) {
+                        return -ENOMEM;
+                }
+                smb2_get_uint32(&vec, 0,
+                                &((struct smb2_srv_copychunk_reply *)ptr)->chunks_written);
+                smb2_get_uint32(&vec, 4,
+                                &((struct smb2_srv_copychunk_reply *)ptr)->chunk_bytes_written);
+                smb2_get_uint32(&vec, 8,
+                                &((struct smb2_srv_copychunk_reply *)ptr)->total_bytes_written);
                 break;
         default:
                 ptr = smb2_alloc_init(smb2, rep->output_count);
@@ -442,4 +493,3 @@ smb2_process_ioctl_request_variable(struct smb2_context *smb2,
         req->input = ptr;
         return 0;
 }
-

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -836,6 +836,145 @@ int smb2_readlink(struct smb2_context *smb2, const char *path,
 	return rc;
 }
 
+static void sync_copy_ioctl_cb(struct smb2_context *smb2, int status,
+                               void *command_data, void *private_data)
+{
+        struct sync_cb_data *cb_data = private_data;
+
+        if (cb_data->status == SMB2_STATUS_CANCELLED) {
+                free(cb_data);
+                return;
+        }
+
+        cb_data->is_finished = 1;
+        cb_data->status = status;
+        cb_data->ptr = command_data;
+}
+
+int smb2_request_resume_key(struct smb2_context *smb2, struct smb2fh *fh,
+                            struct smb2_srv_copychunk_resume_key *resume_key)
+{
+        struct sync_cb_data *cb_data;
+        int rc = 0;
+
+        cb_data = calloc(1, sizeof(struct sync_cb_data));
+        if (cb_data == NULL) {
+                smb2_set_error(smb2, "Failed to allocate sync_cb_data");
+                return -ENOMEM;
+        }
+
+        rc = smb2_request_resume_key_async(smb2, fh, sync_copy_ioctl_cb,
+                                           cb_data);
+        if (rc < 0) {
+                goto out;
+        }
+
+        rc = wait_for_reply(smb2, cb_data);
+        if (rc < 0) {
+                cb_data->status = SMB2_STATUS_CANCELLED;
+                goto out;
+        }
+
+        rc = cb_data->status;
+        if (rc == 0 && cb_data->ptr != NULL) {
+                if (resume_key != NULL) {
+                        memcpy(resume_key, cb_data->ptr, sizeof(*resume_key));
+                }
+                smb2_free_data(smb2, cb_data->ptr);
+                cb_data->ptr = NULL;
+        }
+ out:
+        free(cb_data);
+
+        return rc;
+}
+
+int smb2_copychunk(struct smb2_context *smb2,
+                   uint32_t ctl_code,
+                   const struct smb2_srv_copychunk_resume_key *resume_key,
+                   struct smb2fh *dstfh,
+                   const struct smb2_srv_copychunk *chunks,
+                   uint32_t chunk_count,
+                   struct smb2_srv_copychunk_reply *reply)
+{
+        struct sync_cb_data *cb_data;
+        int rc = 0;
+
+        cb_data = calloc(1, sizeof(struct sync_cb_data));
+        if (cb_data == NULL) {
+                smb2_set_error(smb2, "Failed to allocate sync_cb_data");
+                return -ENOMEM;
+        }
+
+        rc = smb2_copychunk_async(smb2, ctl_code, resume_key, dstfh, chunks,
+                                  chunk_count, sync_copy_ioctl_cb, cb_data);
+        if (rc < 0) {
+                goto out;
+        }
+
+        rc = wait_for_reply(smb2, cb_data);
+        if (rc < 0) {
+                cb_data->status = SMB2_STATUS_CANCELLED;
+                goto out;
+        }
+
+        rc = cb_data->status;
+        if (cb_data->ptr != NULL) {
+                if (reply != NULL) {
+                        memcpy(reply, cb_data->ptr, sizeof(*reply));
+                }
+                smb2_free_data(smb2, cb_data->ptr);
+                cb_data->ptr = NULL;
+        }
+ out:
+        free(cb_data);
+
+        return rc;
+}
+
+int smb2_server_side_copy(struct smb2_context *smb2,
+                          uint32_t ctl_code,
+                          struct smb2fh *srcfh, struct smb2fh *dstfh,
+                          const struct smb2_srv_copychunk *chunks,
+                          uint32_t chunk_count,
+                          struct smb2_srv_copychunk_reply *reply)
+{
+        struct sync_cb_data *cb_data;
+        int rc = 0;
+
+        cb_data = calloc(1, sizeof(struct sync_cb_data));
+        if (cb_data == NULL) {
+                smb2_set_error(smb2, "Failed to allocate sync_cb_data");
+                return -ENOMEM;
+        }
+
+        rc = smb2_server_side_copy_async(smb2, ctl_code, srcfh, dstfh,
+                                         chunks, chunk_count,
+                                         sync_copy_ioctl_cb, cb_data);
+        if (rc < 0) {
+                goto out;
+        }
+
+        rc = wait_for_reply(smb2, cb_data);
+        if (rc < 0) {
+                cb_data->status = SMB2_STATUS_CANCELLED;
+                goto out;
+        }
+
+        rc = cb_data->status;
+        if (cb_data->ptr != NULL) {
+                if (reply != NULL) {
+                        memcpy(reply, cb_data->ptr, sizeof(*reply));
+                }
+                smb2_free_data(smb2, cb_data->ptr);
+                cb_data->ptr = NULL;
+        }
+ out:
+        free(cb_data);
+
+        return rc;
+}
+
 static void sync_echo_cb(struct smb2_context *smb2, int status,
                     void *command_data, void *private_data)
 {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,7 +5,8 @@ AM_CFLAGS = $(WARN_CFLAGS)
 LDADD = ../lib/libsmb2.la
 
 noinst_PROGRAMS = prog_ls prog_mkdir prog_rmdir prog_cat \
-	prog_cat_cancel prog_setsd smb2-dcerpc-coder-test
+	prog_cat_cancel prog_setsd prog_ssc \
+	smb2-dcerpc-coder-test
 noinst_PROGRAMS += metastat-0202-censored
 
 EXTRA_PROGRAMS = ld_sockerr

--- a/tests/prog_ssc.c
+++ b/tests/prog_ssc.c
@@ -1,0 +1,499 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/*
+   Copyright (C) 2026 Rida Shamasneh
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "smb2.h"
+#include "libsmb2.h"
+#include "libsmb2-raw.h"
+
+#define DEFAULT_CHUNK_SIZE (1024 * 1024)
+#define DEFAULT_MAX_CHUNKS 16
+
+enum copy_api {
+        API_COPYCHUNK,
+        API_SERVER_SIDE_COPY,
+};
+
+enum copy_mode {
+        MODE_SYNC,
+        MODE_ASYNC,
+};
+
+struct async_state {
+        int done;
+        int status;
+        void *ptr;
+};
+
+int usage(void)
+{
+        fprintf(stderr,
+                "Usage:\n"
+                "prog_ssc <copychunk|server-side-copy> <sync|async> "
+                "<copychunk|copychunk_write|0xhex> <source-url> <destination-url> "
+                "[chunk-size] [max-chunks-per-request] [start-offset] [length]\n\n"
+                "Examples:\n"
+                "  prog_ssc server-side-copy sync copychunk_write \\\n"
+                "    smb://user@host/share/src.bin smb://user@host/share/dst.bin\n"
+                "  prog_ssc copychunk async copychunk \\\n"
+                "    smb://user@host/share/src.bin smb://user@host/share/dst.bin 1048576 17\n");
+        exit(1);
+}
+
+static int same_or_null(const char *a, const char *b)
+{
+        if (a == NULL || b == NULL) {
+                return a == b;
+        }
+
+        return strcmp(a, b) == 0;
+}
+
+static int wait_for_reply(struct smb2_context *smb2, struct async_state *state)
+{
+        while (!state->done) {
+                struct pollfd pfd;
+
+                memset(&pfd, 0, sizeof(pfd));
+                pfd.fd = smb2_get_fd(smb2);
+                pfd.events = smb2_which_events(smb2);
+
+                if (poll(&pfd, 1, 1000) < 0) {
+                        smb2_set_error(smb2, "Poll failed");
+                        return -1;
+                }
+                if (pfd.revents == 0) {
+                        continue;
+                }
+                if (smb2_service(smb2, pfd.revents) < 0) {
+                        return -1;
+                }
+        }
+
+        return state->status;
+}
+
+static void copy_cb(struct smb2_context *smb2 _U_, int status,
+                    void *command_data, void *private_data)
+{
+        struct async_state *state = private_data;
+
+        state->done = 1;
+        state->status = status;
+        state->ptr = command_data;
+}
+
+static int parse_ctl_code(const char *arg, uint32_t *ctl_code)
+{
+        char *endptr = NULL;
+        unsigned long value;
+
+        if (!strcmp(arg, "copychunk")) {
+            *ctl_code = SMB2_FSCTL_SRV_COPYCHUNK;
+            return 0;
+        }
+        if (!strcmp(arg, "copychunk_write")) {
+            *ctl_code = SMB2_FSCTL_SRV_COPYCHUNK_WRITE;
+            return 0;
+        }
+
+        errno = 0;
+        value = strtoul(arg, &endptr, 0);
+        if (errno != 0 || endptr == arg || *endptr != '\0' ||
+            value > UINT32_MAX) {
+                return -1;
+        }
+
+        *ctl_code = (uint32_t)value;
+        return 0;
+}
+
+static int parse_u32(const char *arg, uint32_t *value)
+{
+        char *endptr = NULL;
+        unsigned long parsed;
+
+        errno = 0;
+        parsed = strtoul(arg, &endptr, 0);
+        if (errno != 0 || endptr == arg || *endptr != '\0' ||
+            parsed > UINT32_MAX) {
+                return -1;
+        }
+
+        *value = (uint32_t)parsed;
+        return 0;
+}
+
+static int parse_u64(const char *arg, uint64_t *value)
+{
+        char *endptr = NULL;
+        unsigned long long parsed;
+
+        errno = 0;
+        parsed = strtoull(arg, &endptr, 0);
+        if (errno != 0 || endptr == arg || *endptr != '\0') {
+                return -1;
+        }
+
+        *value = (uint64_t)parsed;
+        return 0;
+}
+
+static uint32_t build_batch(struct smb2_srv_copychunk *chunks,
+                            uint64_t start_offset, uint64_t remaining,
+                            uint32_t chunk_size, uint32_t max_chunks,
+                            uint64_t *batch_bytes)
+{
+        uint32_t count = 0;
+        uint64_t offset = start_offset;
+        uint64_t total = 0;
+
+        while (count < max_chunks && remaining > 0) {
+                uint32_t length = chunk_size;
+
+                if (remaining < length) {
+                        length = (uint32_t)remaining;
+                }
+
+                chunks[count].source_offset = offset;
+                chunks[count].target_offset = offset;
+                chunks[count].length = length;
+                chunks[count].reserved = 0;
+
+                offset += length;
+                remaining -= length;
+                total += length;
+                count++;
+        }
+
+        *batch_bytes = total;
+        return count;
+}
+
+static int run_copychunk_async(struct smb2_context *smb2, uint32_t ctl_code,
+                               const struct smb2_srv_copychunk_resume_key *resume_key,
+                               struct smb2fh *dstfh,
+                               const struct smb2_srv_copychunk *chunks,
+                               uint32_t chunk_count,
+                               struct smb2_srv_copychunk_reply *reply)
+{
+        struct async_state state;
+        int rc;
+
+        memset(&state, 0, sizeof(state));
+
+        rc = smb2_copychunk_async(smb2, ctl_code, resume_key, dstfh, chunks,
+                                  chunk_count, copy_cb, &state);
+        if (rc < 0) {
+                return rc;
+        }
+
+        rc = wait_for_reply(smb2, &state);
+        if (state.ptr != NULL) {
+                if (reply != NULL) {
+                        memcpy(reply, state.ptr, sizeof(*reply));
+                }
+                smb2_free_data(smb2, state.ptr);
+        }
+
+        return rc;
+}
+
+static int run_server_side_copy_async(struct smb2_context *smb2,
+                                      uint32_t ctl_code,
+                                      struct smb2fh *srcfh,
+                                      struct smb2fh *dstfh,
+                                      const struct smb2_srv_copychunk *chunks,
+                                      uint32_t chunk_count,
+                                      struct smb2_srv_copychunk_reply *reply)
+{
+        struct async_state state;
+        int rc;
+
+        memset(&state, 0, sizeof(state));
+
+        rc = smb2_server_side_copy_async(smb2, ctl_code, srcfh, dstfh, chunks,
+                                         chunk_count, copy_cb, &state);
+        if (rc < 0) {
+                return rc;
+        }
+
+        rc = wait_for_reply(smb2, &state);
+        if (state.ptr != NULL) {
+                if (reply != NULL) {
+                        memcpy(reply, state.ptr, sizeof(*reply));
+                }
+                smb2_free_data(smb2, state.ptr);
+        }
+
+        return rc;
+}
+
+int main(int argc, char *argv[])
+{
+        enum copy_api api;
+        enum copy_mode mode;
+        struct smb2_context *smb2;
+        struct smb2_url *src_url;
+        struct smb2_url *dst_url;
+        struct smb2fh *srcfh = NULL;
+        struct smb2fh *dstfh = NULL;
+        struct smb2_stat_64 st;
+        struct smb2_srv_copychunk_resume_key resume_key;
+        struct smb2_srv_copychunk_reply reply;
+        struct smb2_srv_copychunk *chunks = NULL;
+        uint32_t ctl_code;
+        uint32_t chunk_size = DEFAULT_CHUNK_SIZE;
+        uint32_t max_chunks = DEFAULT_MAX_CHUNKS;
+        uint64_t start_offset = 0;
+        uint64_t requested_length = 0;
+        uint64_t offset;
+        uint64_t remaining;
+        int rc = 1;
+
+        if (argc < 6 || argc > 10) {
+                usage();
+        }
+
+        if (!strcmp(argv[1], "copychunk")) {
+                api = API_COPYCHUNK;
+        } else if (!strcmp(argv[1], "server-side-copy")) {
+                api = API_SERVER_SIDE_COPY;
+        } else {
+                usage();
+        }
+
+        if (!strcmp(argv[2], "sync")) {
+                mode = MODE_SYNC;
+        } else if (!strcmp(argv[2], "async")) {
+                mode = MODE_ASYNC;
+        } else {
+                usage();
+        }
+
+        if (parse_ctl_code(argv[3], &ctl_code) != 0) {
+                fprintf(stderr, "Invalid ctl_code: %s\n", argv[3]);
+                return 1;
+        }
+        if (argc > 6 && parse_u32(argv[6], &chunk_size) != 0) {
+                fprintf(stderr, "Invalid chunk-size: %s\n", argv[6]);
+                return 1;
+        }
+        if (argc > 7 && parse_u32(argv[7], &max_chunks) != 0) {
+                fprintf(stderr, "Invalid max-chunks-per-request: %s\n", argv[7]);
+                return 1;
+        }
+        if (argc > 8 && parse_u64(argv[8], &start_offset) != 0) {
+                fprintf(stderr, "Invalid start-offset: %s\n", argv[8]);
+                return 1;
+        }
+        if (argc > 9 && parse_u64(argv[9], &requested_length) != 0) {
+                fprintf(stderr, "Invalid length: %s\n", argv[9]);
+                return 1;
+        }
+        if (chunk_size == 0 || max_chunks == 0) {
+                fprintf(stderr, "chunk-size and max-chunks-per-request must be non-zero\n");
+                return 1;
+        }
+
+        smb2 = smb2_init_context();
+        if (smb2 == NULL) {
+                fprintf(stderr, "Failed to init context\n");
+                return 1;
+        }
+
+        src_url = smb2_parse_url(smb2, argv[4]);
+        if (src_url == NULL) {
+                fprintf(stderr, "Failed to parse source url: %s\n",
+                        smb2_get_error(smb2));
+                smb2_destroy_context(smb2);
+                return 1;
+        }
+
+        dst_url = smb2_parse_url(smb2, argv[5]);
+        if (dst_url == NULL) {
+                fprintf(stderr, "Failed to parse destination url: %s\n",
+                        smb2_get_error(smb2));
+                smb2_destroy_url(src_url);
+                smb2_destroy_context(smb2);
+                return 1;
+        }
+
+        if (!same_or_null(src_url->domain, dst_url->domain) ||
+            !same_or_null(src_url->server, dst_url->server) ||
+            !same_or_null(src_url->share, dst_url->share) ||
+            !same_or_null(src_url->user, dst_url->user)) {
+                fprintf(stderr,
+                        "Source and destination URLs must use the same domain, server, share, and user\n");
+                goto out;
+        }
+
+        smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
+        if (smb2_connect_share(smb2, src_url->server, src_url->share,
+                               src_url->user) != 0) {
+                fprintf(stderr, "smb2_connect_share failed. %s\n",
+                        smb2_get_error(smb2));
+                goto out;
+        }
+
+        srcfh = smb2_open(smb2, src_url->path, O_RDONLY);
+        if (srcfh == NULL) {
+                fprintf(stderr, "Failed to open source file. %s\n",
+                        smb2_get_error(smb2));
+                goto out_disconnect;
+        }
+
+        if (smb2_fstat(smb2, srcfh, &st) < 0) {
+                fprintf(stderr, "smb2_fstat failed. %s\n", smb2_get_error(smb2));
+                goto out_close_src;
+        }
+
+        if (start_offset > st.smb2_size) {
+                fprintf(stderr, "start-offset is beyond end of source file\n");
+                goto out_close_src;
+        }
+
+        /*
+         * If source and destination name the same file (e.g. to provoke a
+         * server-side rejection of overlapping copy ranges within a single
+         * file), opening the destination with O_TRUNC would truncate the
+         * file out from under the already-open source handle before any
+         * copy is attempted. The file already exists (we just fstat'd it
+         * through srcfh), so just reopen it for read/write.
+         */
+        if (!strcmp(src_url->path, dst_url->path)) {
+                dstfh = smb2_open(smb2, dst_url->path, O_RDWR);
+        } else {
+                dstfh = smb2_open(smb2, dst_url->path, O_RDWR | O_CREAT | O_TRUNC);
+        }
+        if (dstfh == NULL) {
+                fprintf(stderr, "Failed to open destination file. %s\n",
+                        smb2_get_error(smb2));
+                goto out_close_src;
+        }
+
+        remaining = st.smb2_size - start_offset;
+        if (requested_length > 0 && requested_length < remaining) {
+                remaining = requested_length;
+        }
+        offset = start_offset;
+
+        chunks = calloc(max_chunks, sizeof(*chunks));
+        if (chunks == NULL) {
+                fprintf(stderr, "Failed to allocate chunk array\n");
+                goto out_close_dst;
+        }
+
+        if (api == API_COPYCHUNK) {
+                if (smb2_request_resume_key(smb2, srcfh, &resume_key) < 0) {
+                        fprintf(stderr, "smb2_request_resume_key failed. %s\n",
+                                smb2_get_error(smb2));
+                        goto out_free_chunks;
+                }
+        }
+
+        while (remaining > 0) {
+                uint64_t batch_bytes;
+                uint32_t batch_count;
+                int op_rc;
+
+                memset(chunks, 0, max_chunks * sizeof(*chunks));
+                memset(&reply, 0, sizeof(reply));
+
+                batch_count = build_batch(chunks, offset, remaining, chunk_size,
+                                          max_chunks, &batch_bytes);
+                if (batch_count == 0) {
+                        fprintf(stderr, "Failed to build chunk batch\n");
+                        goto out_free_chunks;
+                }
+
+                if (api == API_COPYCHUNK) {
+                        if (mode == MODE_SYNC) {
+                                op_rc = smb2_copychunk(smb2, ctl_code,
+                                                       &resume_key, dstfh,
+                                                       chunks, batch_count,
+                                                       &reply);
+                        } else {
+                                op_rc = run_copychunk_async(smb2, ctl_code,
+                                                            &resume_key, dstfh,
+                                                            chunks, batch_count,
+                                                            &reply);
+                        }
+                } else {
+                        if (mode == MODE_SYNC) {
+                                op_rc = smb2_server_side_copy(smb2, ctl_code,
+                                                              srcfh, dstfh,
+                                                              chunks,
+                                                              batch_count,
+                                                              &reply);
+                        } else {
+                                op_rc = run_server_side_copy_async(smb2,
+                                                                   ctl_code,
+                                                                   srcfh, dstfh,
+                                                                   chunks,
+                                                                   batch_count,
+                                                                   &reply);
+                        }
+                }
+
+                printf("offset=%" PRIu64 " chunks=%" PRIu32 " bytes=%" PRIu64
+                       " status=%d reply={chunks=%" PRIu32
+                       ",chunk_bytes=%" PRIu32 ",total_bytes=%" PRIu32 "}\n",
+                       offset, batch_count, batch_bytes, op_rc,
+                       reply.chunks_written, reply.chunk_bytes_written,
+                       reply.total_bytes_written);
+
+                if (op_rc < 0) {
+                        fprintf(stderr, "copy operation failed. %s\n",
+                                smb2_get_error(smb2));
+                        goto out_free_chunks;
+                }
+
+                offset += batch_bytes;
+                remaining -= batch_bytes;
+        }
+
+        printf("Copied %" PRIu64 " bytes using %s/%s ctl=0x%08" PRIx32 "\n",
+               offset - start_offset,
+               api == API_COPYCHUNK ? "copychunk" : "server-side-copy",
+               mode == MODE_SYNC ? "sync" : "async", ctl_code);
+        rc = 0;
+
+out_free_chunks:
+        free(chunks);
+out_close_dst:
+        if (dstfh != NULL) {
+                smb2_close(smb2, dstfh);
+        }
+out_close_src:
+        if (srcfh != NULL) {
+                smb2_close(smb2, srcfh);
+        }
+out_disconnect:
+        smb2_disconnect_share(smb2);
+out:
+        smb2_destroy_url(dst_url);
+        smb2_destroy_url(src_url);
+        smb2_destroy_context(smb2);
+        return rc;
+}

--- a/tests/test_0600_ssc_basic.sh
+++ b/tests/test_0600_ssc_basic.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+
+. ./functions.sh
+
+echo "Basic server side copy tests"
+
+SRC_BIN=src.bin
+DEST_BIN=dest.bin
+LOCAL_COPY=dest.local
+SRC_BIN_TESTURL=${TESTURL}/$SRC_BIN
+DEST_BIN_TESTURL=${TESTURL}/$DEST_BIN
+
+cleanup_files() {
+    rm -f "$SRC_BIN" "$LOCAL_COPY"
+}
+
+upload_source() {
+    ../utils/smb2-cp "./$SRC_BIN" "$SRC_BIN_TESTURL" > /dev/null || failure
+}
+
+download_dest() {
+    rm -f "$LOCAL_COPY"
+    ../utils/smb2-cp "$DEST_BIN_TESTURL" "./$LOCAL_COPY" > /dev/null || failure
+}
+
+verify_copy() {
+    download_dest
+    cmp "$SRC_BIN" "$LOCAL_COPY" > /dev/null 2>&1 || failure
+}
+
+run_case() {
+    label=$1
+    shift
+
+    echo -n "Testing $label ... "
+    ./prog_ssc "$@" > /dev/null || failure
+    verify_copy
+    success
+}
+
+cleanup_files
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1 count=0 2>/dev/null || failure
+upload_source
+run_case "zero-byte server-side-copy sync copychunk" \
+    server-side-copy sync copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=4096 count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "4 KiB server-side-copy sync copychunk" \
+    server-side-copy sync copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1048575 count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "chunk-minus-1 server-side-copy sync copychunk" \
+    server-side-copy sync copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "1 MiB server-side-copy sync copychunk" \
+    server-side-copy sync copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL" 1048576 16 0 1048576
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=1 > /dev/null 2>&1 || failure
+printf 'x' >> "$SRC_BIN" || failure
+upload_source
+run_case "chunk-plus-1 server-side-copy sync copychunk_write" \
+    server-side-copy sync copychunk_write \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "1 MiB server-side-copy async copychunk" \
+    server-side-copy async copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "1 MiB server-side-copy async copychunk_write" \
+    server-side-copy async copychunk_write \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "1 MiB direct copychunk sync copychunk" \
+    copychunk sync copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "1 MiB direct copychunk sync copychunk_write" \
+    copychunk sync copychunk_write \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "1 MiB direct copychunk async copychunk" \
+    copychunk async copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "1 MiB direct copychunk async copychunk_write" \
+    copychunk async copychunk_write \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=20 > /dev/null 2>&1 || failure
+upload_source
+run_case "20 MiB server-side-copy sync copychunk" \
+    server-side-copy sync copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+dd if=/dev/urandom of="$SRC_BIN" bs=1M count=20 > /dev/null 2>&1 || failure
+upload_source
+run_case "20 MiB server-side-copy sync copychunk_write" \
+    server-side-copy sync copychunk_write \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+echo -n "Testing invalid ctl_code rejection ... "
+./prog_ssc server-side-copy sync 0 \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL" > /dev/null 2>&1 && failure
+success
+
+# Requests more chunks in a single copychunk than the server supports
+# (observed server limit is 256 chunks per request). This must be rejected
+# by the *server*, not by client-side validation, so it exercises the
+# server error/reply parsing path instead of the argument-checking path
+# that "invalid ctl_code rejection" above exercises.
+#
+# The server reports this failure with STATUS_INVALID_PARAMETER using the
+# normal IOCTL reply layout (carrying its copy limits in the output
+# buffer) rather than the generic SMB2 error layout. Older/buggy handling
+# of that case misparses the reply as a generic error and aborts with
+# "Failed to parse fixed part of command payload. Unexpected size of
+# Error reply." instead of a clean NT-status failure.
+dd if=/dev/urandom of="$SRC_BIN" bs=1 count=512 > /dev/null 2>&1 || failure
+upload_source
+echo -n "Testing server-rejected copychunk (chunk count exceeds server limit) ... "
+output=$(./prog_ssc server-side-copy sync copychunk_write \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL" 1 257 2>&1)
+
+rc=$?
+if [ "$rc" -eq 0 ] || [ "$rc" -ge 128 ]; then
+    failure
+fi
+case "$output" in
+    *"Failed to parse"*|*"Unexpected size of Error reply"*)
+        failure
+        ;;
+esac
+success
+
+# Copies a file onto itself, so every chunk's source range and target
+# range are identical (the simplest form of an overlapping copy within a
+# single file). The server may legitimately reject this outright, or treat
+# it as a no-op, depending on implementation -- either is acceptable here.
+# What matters is that whatever status it uses to report this doesn't get
+# misparsed the way the chunk-count-limit status did above. A wrong format
+# guess in the *other* direction (treating a plain generic-error reply as
+# IOCTL-shaped) wouldn't necessarily fail this request itself -- it could
+# instead desync the stream and only surface as a failure on the *next*
+# request, so a normal copy is run immediately afterward to catch that.
+dd if=/dev/urandom of="$SRC_BIN" bs=65536 count=1 > /dev/null 2>&1 || failure
+upload_source
+echo -n "Testing self-overlapping copychunk (source == destination) ... "
+output=$(./prog_ssc server-side-copy sync copychunk_write \
+    "$SRC_BIN_TESTURL" "$SRC_BIN_TESTURL" 2>&1)
+rc=$?
+if [ "$rc" -ge 128 ]; then
+    failure
+fi
+case "$output" in
+    *"Failed to parse"*|*"Unexpected size of Error reply"*)
+        failure
+        ;;
+esac
+success
+
+dd if=/dev/urandom of="$SRC_BIN" bs=4096 count=1 > /dev/null 2>&1 || failure
+upload_source
+run_case "post-self-overlap sanity server-side-copy sync copychunk" \
+    server-side-copy sync copychunk \
+    "$SRC_BIN_TESTURL" "$DEST_BIN_TESTURL"
+
+cleanup_files
+
+exit 0


### PR DESCRIPTION
Adds client support for SMB2 server-side copy: request a resume key for an open source file (FSCTL_SRV_REQUEST_RESUME_KEY), then copy chunks into an open destination file (FSCTL_SRV_COPYCHUNK / _WRITE). New API: smb2_request_resume_key(), smb2_copychunk(), and a smb2_server_side_copy() convenience wrapper that does both steps in one call, each with sync and async variants.

Two correctness bugs were found and fixed while wiring up the IOCTL reply path for these ctl codes:

- struct smb2_ioctl_reply was left partially uninitialized when a reply carried no output body, so smb2_copychunk()/smb2_server_side_copy() could memcpy/smb2_free_data() a garbage pointer on any copychunk error that didn't come with limit info attached.

- FSCTL_SRV_COPYCHUNK{,_WRITE} report the chunk-count/size limit-exceeded error as STATUS_INVALID_PARAMETER but still shape the reply as a normal IOCTL response (limits in the output buffer), not the generic SMB2 error format. The reply dispatcher routed it to the generic error parser regardless, desyncing the read. The request's ctl_code is now retained on the pdu (mirroring the existing info_type/file_info_class fields kept for QUERY_INFO) so the dispatcher can tell the two reply formats apart.

Also includes:
- smb2-server-side-copy-sync example and prog_ssc test program, covering sync/async and direct-copychunk/server-side-copy-helper paths for both FSCTL variants
- negative tests that provoke real server-side rejections (chunk count over the server's limit, overlapping source/destination ranges) rather than only client-side argument validation
- reuse a single resume key across all batches of a copy instead of re-requesting one per batch