### PR TITLE
Propagate SMB domain from parsed URLs

### DIFF
--- a/examples/dcerpc.c
+++ b/examples/dcerpc.c
@@ -202,6 +202,9 @@ int main(int argc, char *argv[])
         if (url->user) {
                 smb2_set_user(smb2, url->user);
         }
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 

--- a/examples/picow/main.cpp
+++ b/examples/picow/main.cpp
@@ -27,6 +27,10 @@ int smb2_ls_sync(char* user_url)
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) < 0) {

--- a/examples/smb2-CMD-FIND.c
+++ b/examples/smb2-CMD-FIND.c
@@ -302,6 +302,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share_async(smb2, url->server, url->share, url->user,

--- a/examples/smb2-cat-async.c
+++ b/examples/smb2-cat-async.c
@@ -153,6 +153,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share_async(smb2, url->server, url->share, url->user,
                                      cf_cb, (void *)url->path) != 0) {

--- a/examples/smb2-cat-sync.c
+++ b/examples/smb2-cat-sync.c
@@ -67,6 +67,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/examples/smb2-ftruncate-sync.c
+++ b/examples/smb2-ftruncate-sync.c
@@ -59,6 +59,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/examples/smb2-ls-async.c
+++ b/examples/smb2-ls-async.c
@@ -154,6 +154,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share_async(smb2, url->server, url->share, url->user, cf_cb, (void *)url->path) != 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/examples/smb2-ls-epoll.c
+++ b/examples/smb2-ls-epoll.c
@@ -182,6 +182,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 

--- a/examples/smb2-lsa-lookupsids.c
+++ b/examples/smb2-lsa-lookupsids.c
@@ -242,6 +242,9 @@ int main(int argc, char *argv[])
         if (url->user) {
                 smb2_set_user(smb2, url->user);
         }
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 

--- a/examples/smb2-lseek-sync.c
+++ b/examples/smb2-lseek-sync.c
@@ -62,6 +62,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/examples/smb2-notify.c
+++ b/examples/smb2-notify.c
@@ -118,6 +118,9 @@ int main(int argc, char *argv[])
         if (url->user) {
                 smb2_set_user(smb2, url->user);
         }
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/examples/smb2-put-async.c
+++ b/examples/smb2-put-async.c
@@ -125,6 +125,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/examples/smb2-put-sync.c
+++ b/examples/smb2-put-sync.c
@@ -74,6 +74,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/examples/smb2-raw-fsstat-async.c
+++ b/examples/smb2-raw-fsstat-async.c
@@ -314,6 +314,9 @@ int main(int argc, char *argv[])
         if (url->user) {
                 smb2_set_user(smb2, url->user);
         }
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/examples/smb2-raw-getsd-async.c
+++ b/examples/smb2-raw-getsd-async.c
@@ -362,6 +362,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/examples/smb2-raw-stat-async.c
+++ b/examples/smb2-raw-stat-async.c
@@ -235,6 +235,9 @@ int main(int argc, char *argv[])
         if (url->user) {
                 smb2_set_user(smb2, url->user);
         }
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/examples/smb2-readlink.c
+++ b/examples/smb2-readlink.c
@@ -58,6 +58,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) < 0) {

--- a/examples/smb2-rename-sync.c
+++ b/examples/smb2-rename-sync.c
@@ -59,6 +59,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/examples/smb2-server-side-copy-sync.c
+++ b/examples/smb2-server-side-copy-sync.c
@@ -103,6 +103,9 @@ int main(int argc, char *argv[])
                 rc = 1;
                 goto out;
         }
+        if (src_url->domain) {
+                smb2_set_domain(smb2, src_url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
         if (smb2_connect_share(smb2, src_url->server, src_url->share, src_url->user) != 0) {

--- a/examples/smb2-set-security-info.c
+++ b/examples/smb2-set-security-info.c
@@ -234,6 +234,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
         if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {
                 printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/examples/smb2-share-enum-sync.c
+++ b/examples/smb2-share-enum-sync.c
@@ -120,6 +120,9 @@ int main(int argc, char *argv[])
         if (url->user) {
                 smb2_set_user(smb2, url->user);
         }
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 

--- a/examples/smb2-share-enum.c
+++ b/examples/smb2-share-enum.c
@@ -168,6 +168,9 @@ int main(int argc, char *argv[])
         if (url->user) {
                 smb2_set_user(smb2, url->user);
         }
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 

--- a/examples/smb2-share-info.c
+++ b/examples/smb2-share-info.c
@@ -205,6 +205,9 @@ int main(int argc, char *argv[])
         if (url->user) {
                 smb2_set_user(smb2, url->user);
         }
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 

--- a/examples/smb2-stat-sync.c
+++ b/examples/smb2-stat-sync.c
@@ -61,6 +61,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/examples/smb2-statvfs-sync.c
+++ b/examples/smb2-statvfs-sync.c
@@ -62,6 +62,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/examples/smb2-truncate-sync.c
+++ b/examples/smb2-truncate-sync.c
@@ -58,6 +58,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {

--- a/tests/prog_cat.c
+++ b/tests/prog_cat.c
@@ -155,6 +155,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share_async(smb2, url->server, url->share, url->user,
                                      cf_cb, (void *)url->path) != 0) {

--- a/tests/prog_cat_cancel.c
+++ b/tests/prog_cat_cancel.c
@@ -169,6 +169,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share_async(smb2, url->server, url->share, url->user,
                                      cf_cb, (void *)url->path) != 0) {

--- a/tests/prog_ls.c
+++ b/tests/prog_ls.c
@@ -122,6 +122,10 @@ int main(int argc, char *argv[])
                 exit(1);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) < 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/tests/prog_mkdir.c
+++ b/tests/prog_mkdir.c
@@ -63,6 +63,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) < 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/tests/prog_rmdir.c
+++ b/tests/prog_rmdir.c
@@ -63,6 +63,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) < 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/tests/prog_setsd.c
+++ b/tests/prog_setsd.c
@@ -342,6 +342,10 @@ int main(int argc, char *argv[])
                 exit(0);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
         if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {
                 printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));

--- a/tests/prog_ssc.c
+++ b/tests/prog_ssc.c
@@ -347,6 +347,9 @@ int main(int argc, char *argv[])
                         "Source and destination URLs must use the same domain, server, share, and user\n");
                 goto out;
         }
+        if (src_url->domain) {
+                smb2_set_domain(smb2, src_url->domain);
+        }
 
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
         if (smb2_connect_share(smb2, src_url->server, src_url->share,

--- a/utils/smb2-cp.c
+++ b/utils/smb2-cp.c
@@ -166,6 +166,9 @@ open_file(const char *url, int flags)
 		free_file_context(file_context);
 		return NULL;
 	}
+	if (file_context->url->domain) {
+		smb2_set_domain(file_context->smb2, file_context->url->domain);
+	}
 
 	if (smb2_connect_share(file_context->smb2, file_context->url->server,
 			       file_context->url->share,

--- a/utils/smb2-ls.c
+++ b/utils/smb2-ls.c
@@ -68,6 +68,10 @@ int main(int argc, char *argv[])
                 exit(1);
         }
 
+        if (url->domain) {
+                smb2_set_domain(smb2, url->domain);
+        }
+
         smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
 	if (smb2_connect_share(smb2, url->server, url->share, url->user) < 0) {
 		printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));


### PR DESCRIPTION
In many examples, test programs, and utilities, the code already parsed SMB URLs of the form smb://[domain;][user@]host/share/path, but it only passed url->user into the SMB context before connecting. This commit adds the missing step:
```
  if (url->domain) {
      smb2_set_domain(smb2, url->domain);
  }
```
Prior to this change, the parser extracted the domain, but most callers simply discarded it. This PR also handles the case where an empty domain "" is passed in the URL, e.g.:
```
smb://\;[user@]host/share/path
"smb://;[user@]host/share/path"
```