### PR TITLE
Add SMB2 support for creating links, with an example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,12 +19,22 @@ set(SOURCES smb2-cat-async
             smb2-CMD-FIND
             smb2-server-sync
             smb2-notify
-            smb2-set-security-info)
+            smb2-set-security-info
+            smb2-link-sync)
 
 foreach(TARGET ${SOURCES})
   add_executable(${TARGET} ${TARGET}.c)
   target_link_libraries(${TARGET} smb2 ${CORE_LIBRARIES})
   add_dependencies(${TARGET} smb2)
+  if(WIN32 AND BUILD_SHARED_LIBS)
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_FILE:smb2> $<TARGET_FILE_DIR:${TARGET}>)
+  endif()
 endforeach()
 
-add_definitions(-Werror "-D_U_=__attribute__((unused))")
+if(NOT MSVC)
+  add_definitions(-Werror "-D_U_=__attribute__((unused))")
+else()
+  add_definitions("-D_U_=")
+endif()

--- a/examples/smb2-link-sync.c
+++ b/examples/smb2-link-sync.c
@@ -1,0 +1,93 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/*
+   Copyright (C) 2026 by Dan Brakeley <dan@brakeley.net>
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _GNU_SOURCE
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <poll.h>
+#endif
+
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+
+#include "smb2.h"
+#include "libsmb2.h"
+#include "libsmb2-raw.h"
+
+int usage(void)
+{
+        fprintf(stderr, "Usage:\n"
+                "smb2-link-sync <smb2-share-url> <src-file> <link-file>\n\n"
+                "URL format: "
+                "smb://[<domain;][<username>@]<host>>[:<port>]/<share>/\n");
+        exit(1);
+}
+
+int main(int argc, char *argv[])
+{
+        struct smb2_context *smb2;
+        struct smb2_url *url;
+#ifdef _WIN32
+        WSADATA wsaData;
+
+        if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
+                printf("Failed to start Winsock2\n");
+                return 10;
+        }
+#endif
+
+        if (argc < 4) {
+                usage();
+        }
+
+        smb2 = smb2_init_context();
+        if (smb2 == NULL) {
+                fprintf(stderr, "Failed to init context\n");
+                exit(0);
+        }
+
+        url = smb2_parse_url(smb2, argv[1]);
+        if (url == NULL) {
+                fprintf(stderr, "Failed to parse url: %s\n",
+                        smb2_get_error(smb2));
+                exit(0);
+        }
+
+        smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
+
+        if (smb2_connect_share(smb2, url->server, url->share, url->user) != 0) {
+                printf("smb2_connect_share failed. %s\n", smb2_get_error(smb2));
+                exit(10);
+        }
+
+        printf("Creating hard link %s -> %s\n", argv[3], argv[2]);
+        if (smb2_link(smb2, argv[2], argv[3]) < 0) {
+                printf("smb2_link failed. %s\n", smb2_get_error(smb2));
+                exit(10);
+        }
+
+        smb2_disconnect_share(smb2);
+        smb2_destroy_url(url);
+        smb2_destroy_context(smb2);
+
+        return 0;
+}

--- a/include/smb2/libsmb2.h
+++ b/include/smb2/libsmb2.h
@@ -709,7 +709,7 @@ struct smb2dir *smb2_opendir(struct smb2_context *smb2, const char *path);
 
 int smb2_opendir_async(struct smb2_context *smb2, const char *path,
                        smb2_command_cb cb, void *cb_data);
-        
+
 /*
  * closedir()
  */
@@ -786,14 +786,14 @@ struct smb2fh;
 struct smb2_pdu *
 smb2_open_async_pdu(struct smb2_context *smb2, const char *path, int flags,
                     smb2_command_cb cb, void *cb_data, void (*free_cb)(void *));
-        
+
 /*
  * Returns
  *  0     : The operation was initiated. Result of the operation will be
  *          reported through the callback function.
  * -errno : There was an error. The callback function will not be invoked.
  *
- */  
+ */
 int smb2_open_async_with_oplock_or_lease(struct smb2_context *smb2, const char *path, int flags,
                     uint8_t oplock_level, uint32_t lease_state, smb2_lease_key lease_key,
                     smb2_command_cb cb, void *cb_data);
@@ -1179,6 +1179,27 @@ int smb2_rename_async(struct smb2_context *smb2, const char *oldpath,
  * Sync rename()
  */
 int smb2_rename(struct smb2_context *smb2, const char *oldpath,
+                const char *newpath);
+
+/*
+ * Async link()
+ *
+ * Returns
+ *  0     : The operation was initiated. Result of the operation will be
+ *          reported through the callback function.
+ * -errno : There was an error. The callback function will not be invoked.
+ *
+ * When the callback is invoked, status indicates the result:
+ *      0 : Success.
+ * -errno : An error occurred.
+ */
+int smb2_link_async(struct smb2_context *smb2, const char *oldpath,
+                    const char *newpath, smb2_command_cb cb, void *cb_data);
+
+/*
+ * Sync link()
+ */
+int smb2_link(struct smb2_context *smb2, const char *oldpath,
               const char *newpath);
 
 /*

--- a/include/smb2/smb2.h
+++ b/include/smb2/smb2.h
@@ -724,6 +724,14 @@ struct smb2_file_rename_info {
 };
 
 /*
+ * SMB2_FILE_LINK_INFORMATION.
+ */
+struct smb2_file_link_info {
+        uint8_t replace_if_exist;
+        const uint8_t* file_name;
+};
+
+/*
  * FILE_NETWORK_OPEN_INFORMATION
  */
 struct smb2_file_network_open_info {

--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -1327,15 +1327,15 @@ smb2_open_async_pdu(struct smb2_context *smb2, const char *path, int flags,
                 SMB2_OPLOCK_LEVEL_NONE, 0, NULL,
                 cb, cb_data, free_cb, 1);
 }
-        
+
 int
 smb2_open_async_with_oplock_or_lease(struct smb2_context *smb2, const char *path, int flags,
                 uint8_t oplock_level, uint32_t lease_state, smb2_lease_key lease_key,
                 smb2_command_cb cb, void *cb_data)
-        
+
 {
         struct smb2_pdu *pdu;
-        
+
         pdu = _smb2_open_async_with_oplock_or_lease(smb2, path, flags,
                 oplock_level, lease_state, lease_key,
                 cb, cb_data, NULL, 0);
@@ -1347,7 +1347,7 @@ smb2_open_async(struct smb2_context *smb2, const char *path, int flags,
                 smb2_command_cb cb, void *cb_data)
 {
         struct smb2_pdu *pdu;
-        
+
         pdu = _smb2_open_async_with_oplock_or_lease(smb2, path, flags,
                 SMB2_OPLOCK_LEVEL_NONE, 0, NULL,
                 cb, cb_data, NULL, 0);
@@ -2320,87 +2320,91 @@ smb2_truncate_async(struct smb2_context *smb2, const char *path,
         return 0;
 }
 
-struct rename_cb_data {
+/* *new_name* is used for both renaming and creating hard links */
+struct new_name_cb_data {
         uint8_t *newpath;
         smb2_command_cb cb;
         void *cb_data;
         uint32_t status;
 };
 
-static void free_rename_data(struct rename_cb_data *rename_data)
+static void free_new_name_data(struct new_name_cb_data *new_name_data)
 {
-        free(rename_data->newpath);
-        free(rename_data);
+        free(new_name_data->newpath);
+        free(new_name_data);
 }
 
 static void
-rename_cb_3(struct smb2_context *smb2, int status,
+new_name_cb_3(struct smb2_context *smb2, int status,
            void *command_data _U_, void *private_data)
 {
-        struct rename_cb_data *rename_data = private_data;
+        struct new_name_cb_data *new_name_data = private_data;
 
-        if (rename_data->status == SMB2_STATUS_SUCCESS) {
-                rename_data->status = status;
+        if (new_name_data->status == SMB2_STATUS_SUCCESS) {
+                new_name_data->status = status;
         }
 
-        rename_data->cb(smb2, -nterror_to_errno(rename_data->status),
-                        NULL, rename_data->cb_data);
-        free_rename_data(rename_data);
+        new_name_data->cb(smb2, -nterror_to_errno(new_name_data->status),
+                        NULL, new_name_data->cb_data);
+        free_new_name_data(new_name_data);
 }
 
 static void
-rename_cb_2(struct smb2_context *smb2, int status,
+new_name_cb_2(struct smb2_context *smb2, int status,
            void *command_data _U_, void *private_data)
 {
-        struct rename_cb_data *rename_data = private_data;
+        struct new_name_cb_data *new_name_data = private_data;
 
-        if (rename_data->status == SMB2_STATUS_SUCCESS) {
-                rename_data->status = status;
+        if (new_name_data->status == SMB2_STATUS_SUCCESS) {
+                new_name_data->status = status;
         }
 }
 
 static void
-rename_cb_1(struct smb2_context *smb2, int status,
+new_name_cb_1(struct smb2_context *smb2, int status,
            void *command_data _U_, void *private_data)
 {
-        struct rename_cb_data *rename_data = private_data;
+        struct new_name_cb_data *new_name_data = private_data;
 
-        if (rename_data->status == SMB2_STATUS_SUCCESS) {
-                rename_data->status = status;
+        if (new_name_data->status == SMB2_STATUS_SUCCESS) {
+                new_name_data->status = status;
         }
 }
 
-int
-smb2_rename_async(struct smb2_context *smb2, const char *oldpath,
-                  const char *newpath, smb2_command_cb cb, void *cb_data)
+static int
+smb2_new_name_async(struct smb2_context *smb2, const char *oldpath,
+                    const char *newpath, uint8_t file_info_class,
+                    uint32_t desired_access,
+                    smb2_command_cb cb, void *cb_data)
 {
-        struct rename_cb_data *rename_data;
+        struct new_name_cb_data *new_name_data;
         struct smb2_create_request cr_req;
         struct smb2_set_info_request si_req;
         struct smb2_close_request cl_req;
         struct smb2_pdu *pdu, *next_pdu;
-        struct smb2_file_rename_info rn_info _U_;
+        struct smb2_file_rename_info rn_info;
+        struct smb2_file_link_info ln_info;
         uint8_t *ptr;
 
         if (smb2 == NULL) {
                 return -EINVAL;
         }
 
-        rename_data = calloc(1, sizeof(struct rename_cb_data));
-        if (rename_data == NULL) {
-                smb2_set_error(smb2, "Failed to allocate rename_data");
+        new_name_data = calloc(1, sizeof(struct new_name_cb_data));
+        if (new_name_data == NULL) {
+                smb2_set_error(smb2, "Failed to allocate new_name_data");
                 return -ENOMEM;
         }
 
-        rename_data->cb = cb;
-        rename_data->cb_data = cb_data;
-        rename_data->newpath = (uint8_t *)strdup(newpath);
-        if (rename_data->newpath == NULL) {
-                free_rename_data(rename_data);
-                smb2_set_error(smb2, "Failed to allocate rename_data->newpath");
+        new_name_data->cb = cb;
+        new_name_data->cb_data = cb_data;
+        new_name_data->newpath = (uint8_t *)strdup(newpath);
+        if (new_name_data->newpath == NULL) {
+                free_new_name_data(new_name_data);
+                smb2_set_error(smb2, "Failed to allocate new_name_data->newpath");
                 return -ENOMEM;
         }
-        for (ptr = rename_data->newpath; *ptr; ptr++) {
+        for (ptr = new_name_data->newpath; *ptr; ptr++) {
                 if (*ptr == '/') {
                         *ptr = '\\';
                 }
@@ -2410,37 +2414,42 @@ smb2_rename_async(struct smb2_context *smb2, const char *oldpath,
         memset(&cr_req, 0, sizeof(struct smb2_create_request));
         cr_req.requested_oplock_level = SMB2_OPLOCK_LEVEL_NONE;
         cr_req.impersonation_level = SMB2_IMPERSONATION_IMPERSONATION;
-        cr_req.desired_access = SMB2_GENERIC_READ  | SMB2_FILE_READ_ATTRIBUTES | SMB2_DELETE;
+        cr_req.desired_access = desired_access;
         cr_req.file_attributes = 0;
         cr_req.share_access = SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE;
         cr_req.create_disposition = SMB2_FILE_OPEN;
         cr_req.create_options = 0;
         cr_req.name = oldpath;
 
-        pdu = smb2_cmd_create_async(smb2, &cr_req, rename_cb_1, rename_data);
+        pdu = smb2_cmd_create_async(smb2, &cr_req, new_name_cb_1, new_name_data);
         if (pdu == NULL) {
                 smb2_set_error(smb2, "Failed to create create command");
-                free_rename_data(rename_data);
+                free_new_name_data(new_name_data);
                 return -EINVAL;
         }
 
         /* SET INFO command */
-        rn_info.replace_if_exist = 0;
-        rn_info.file_name = rename_data->newpath;
-
         memset(&si_req, 0, sizeof(struct smb2_set_info_request));
         si_req.info_type = SMB2_0_INFO_FILE;
-        si_req.file_info_class = SMB2_FILE_RENAME_INFORMATION;
+        si_req.file_info_class = file_info_class;
         si_req.additional_information = 0;
         memcpy(si_req.file_id, compound_file_id, SMB2_FD_SIZE);
-        si_req.input_data = &rn_info;
+        if (file_info_class == SMB2_FILE_LINK_INFORMATION) {
+                ln_info.replace_if_exist = 0;
+                ln_info.file_name = new_name_data->newpath;
+                si_req.input_data = &ln_info;
+        } else {
+                rn_info.replace_if_exist = 0;
+                rn_info.file_name = new_name_data->newpath;
+                si_req.input_data = &rn_info;
+        }
 
         next_pdu = smb2_cmd_set_info_async(smb2, &si_req,
-                                           rename_cb_2, rename_data);
+                                           new_name_cb_2, new_name_data);
         if (next_pdu == NULL) {
                 smb2_set_error(smb2, "Failed to create set command. %s",
                                smb2_get_error(smb2));
-                free_rename_data(rename_data);
+                free_new_name_data(new_name_data);
                 smb2_free_pdu(smb2, pdu);
                 return -EINVAL;
         }
@@ -2451,10 +2460,10 @@ smb2_rename_async(struct smb2_context *smb2, const char *oldpath,
         cl_req.flags = SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB;
         memcpy(cl_req.file_id, compound_file_id, SMB2_FD_SIZE);
 
-        next_pdu = smb2_cmd_close_async(smb2, &cl_req, rename_cb_3, rename_data);
+        next_pdu = smb2_cmd_close_async(smb2, &cl_req, new_name_cb_3, new_name_data);
         if (next_pdu == NULL) {
-                rename_data->cb(smb2, -ENOMEM, NULL, rename_data->cb_data);
-                free_rename_data(rename_data);
+                new_name_data->cb(smb2, -ENOMEM, NULL, new_name_data->cb_data);
+                free_new_name_data(new_name_data);
                 smb2_free_pdu(smb2, pdu);
                 return -EINVAL;
         }
@@ -2463,6 +2472,30 @@ smb2_rename_async(struct smb2_context *smb2, const char *oldpath,
         smb2_queue_pdu(smb2, pdu);
 
         return 0;
+}
+
+int
+smb2_rename_async(struct smb2_context *smb2, const char *oldpath,
+                  const char *newpath, smb2_command_cb cb, void *cb_data)
+{
+        return smb2_new_name_async(smb2, oldpath, newpath,
+                                   SMB2_FILE_RENAME_INFORMATION,
+                                   SMB2_GENERIC_READ |
+                                   SMB2_FILE_READ_ATTRIBUTES |
+                                   SMB2_DELETE,
+                                   cb, cb_data);
+}
+
+int
+smb2_link_async(struct smb2_context *smb2, const char *oldpath,
+                const char *newpath, smb2_command_cb cb, void *cb_data)
+{
+        /* Unlike rename, creating a hard link does not need SMB2_DELETE
+         * access to the source file. */
+        return smb2_new_name_async(smb2, oldpath, newpath,
+                                   SMB2_FILE_LINK_INFORMATION,
+                                   SMB2_FILE_READ_ATTRIBUTES,
+                                   cb, cb_data);
 }
 
 static void

--- a/lib/libsmb2.syms
+++ b/lib/libsmb2.syms
@@ -137,6 +137,8 @@ smb2_telldir
 smb2_timeval_to_win
 smb2_truncate
 smb2_truncate_async
+smb2_link
+smb2_link_async
 smb2_rename
 smb2_rename_async
 smb2_unlink

--- a/lib/smb2-cmd-set-info.c
+++ b/lib/smb2-cmd-set-info.c
@@ -55,18 +55,68 @@
 #include "libsmb2.h"
 #include "libsmb2-private.h"
 
+/*
+ * FILE_RENAME_INFORMATION and FILE_LINK_INFORMATION share the same wire
+ * format: ReplaceIfExists, Reserved, RootDirectory, FileNameLength, FileName.
+ */
+static int
+smb2_encode_new_name(struct smb2_context *smb2, struct smb2_pdu *pdu,
+                     struct smb2_iovec *iov, uint8_t replace_if_exist,
+                     const uint8_t *file_name)
+{
+        int i, len;
+        uint8_t *buf;
+        struct smb2_utf16 *name;
+
+        name = smb2_utf8_to_utf16((char *)file_name);
+        if (name == NULL) {
+                smb2_set_error(smb2, "Could not convert name into UTF-16");
+                return -1;
+        }
+        /* Convert '/' to '\' in-place before copying into the iovec */
+        for (i = 0; i < name->len; i++) {
+                if (name->val[i] == 0x002f) {
+                        name->val[i] = 0x005c;
+                }
+        }
+
+        len = 28 + name->len * 2;
+        smb2_set_uint32(iov, 4, len); /* buffer length */
+
+        buf = calloc(len, sizeof(uint8_t));
+        if (buf == NULL) {
+                smb2_set_error(smb2, "Failed to allocate set info data buffer");
+                free(name);
+                return -1;
+        }
+        iov = smb2_add_iovector(smb2, &pdu->out, buf, len, free);
+        if (iov == NULL) {
+                smb2_set_error(smb2, "Failed to add iovector for set-info new-name data");
+                free(name);
+                return -1;
+        }
+
+        smb2_set_uint8(iov, 0, replace_if_exist);
+        smb2_set_uint64(iov, 8, 0u);
+        smb2_set_uint32(iov, 16, name->len * 2);
+        memcpy(iov->buf + 20, name->val, name->len * 2);
+        free(name);
+
+        return 0;
+}
+
 static int
 smb2_encode_set_info_request(struct smb2_context *smb2,
                              struct smb2_pdu *pdu,
                              struct smb2_set_info_request *req)
 {
-        int i, len;
+        int len;
         uint8_t *buf;
         struct smb2_iovec *iov;
         struct smb2_file_end_of_file_info *eofi;
         struct smb2_file_disposition_info *fdi;
         struct smb2_file_rename_info *rni;
-        struct smb2_utf16 *name;
+        struct smb2_file_link_info *lni;
         struct smb2_security_descriptor *sd;
 
         len = SMB2_SET_INFO_REQUEST_SIZE & 0xfffffffe;
@@ -152,43 +202,19 @@ smb2_encode_set_info_request(struct smb2_context *smb2,
                         break;
                 case SMB2_FILE_RENAME_INFORMATION:
                         rni = req->input_data;
-
-                        name = smb2_utf8_to_utf16((char *)(rni->file_name));
-                        if (name == NULL) {
-                                smb2_set_error(smb2, "Could not convert name into UTF-16");
+                        if (smb2_encode_new_name(smb2, pdu, iov,
+                                                 rni->replace_if_exist,
+                                                 rni->file_name) < 0) {
                                 return -1;
                         }
-                        /* Convert '/' to '\' in-place before copying into the iovec */
-                        for (i = 0; i < name->len; i++) {
-                                if (name->val[i] == 0x002f) {
-                                        name->val[i] = 0x005c;
-                                }
-                        }
-
-                        len = 28 + name->len * 2;
-                        smb2_set_uint32(iov, 4, len); /* buffer length */
-
-                        buf = calloc(len, sizeof(uint8_t));
-                        if (buf == NULL) {
-                                smb2_set_error(smb2, "Failed to allocate set "
-                                               "info data buffer");
-                                free(name);
+                        break;
+                case SMB2_FILE_LINK_INFORMATION:
+                        lni = req->input_data;
+                        if (smb2_encode_new_name(smb2, pdu, iov,
+                                                 lni->replace_if_exist,
+                                                 lni->file_name) < 0) {
                                 return -1;
                         }
-                        iov = smb2_add_iovector(smb2, &pdu->out, buf, len,
-                                                free);
-                        if (iov == NULL) {
-                                smb2_set_error(smb2, "Failed to add iovector for set-info rename data");
-                                free(name);
-                                return -1;
-                        }
-
-                        smb2_set_uint8(iov, 0, rni->replace_if_exist);
-                        smb2_set_uint64(iov, 8, 0u);
-                        smb2_set_uint32(iov, 16, name->len * 2);
-                        memcpy(iov->buf + 20, name->val, name->len * 2);
-                        free(name);
-
                         break;
                 case SMB2_FILE_DISPOSITION_INFORMATION:
                         len = 1;

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -84,7 +84,7 @@ static int wait_for_reply(struct smb2_context *smb2,
 		{
 			smb2_set_error(smb2, "Timeout expired and no connection exists\n");
 			return -1;
-		}                
+		}
                 if (pfd.revents == 0) {
                         continue;
                 }
@@ -119,7 +119,7 @@ static void sync_connect_cb(struct smb2_context *smb2, int status,
  */
 int smb2_connect_share(struct smb2_context *smb2,
                        const char *server,
-                       const char *share,                      
+                       const char *share,
                        const char *user)
 {
         struct sync_cb_data *cb_data;
@@ -390,7 +390,7 @@ int smb2_pread(struct smb2_context *smb2, struct smb2fh *fh,
                 smb2_set_error(smb2, "Failed to allocate sync_cb_data");
                 return -ENOMEM;
         }
-        
+
 	rc = smb2_pread_async(smb2, fh, buf, count, offset,
                               sync_generic_status_cb, cb_data);
         if (rc < 0) {
@@ -483,7 +483,7 @@ int smb2_write(struct smb2_context *smb2, struct smb2fh *fh,
                 smb2_set_error(smb2, "Failed to allocate sync_cb_data");
                 return -ENOMEM;
         }
-        
+
 	rc = smb2_write_async(smb2, fh, buf, count,
                               sync_generic_status_cb, cb_data);
         if (rc < 0) {
@@ -543,7 +543,7 @@ int smb2_rmdir(struct smb2_context *smb2, const char *path)
                 smb2_set_error(smb2, "Failed to allocate sync_cb_data");
                 return -ENOMEM;
         }
-        
+
 	rc = smb2_rmdir_async(smb2, path,
                               sync_generic_status_cb, cb_data);
         if (rc < 0) {
@@ -686,6 +686,37 @@ int smb2_rename(struct smb2_context *smb2, const char *oldpath,
 	return rc;
 }
 
+int smb2_link(struct smb2_context *smb2, const char *oldpath,
+                const char *newpath)
+{
+        struct sync_cb_data *cb_data;
+        int rc = 0;
+
+        cb_data = calloc(1, sizeof(struct sync_cb_data));
+        if (cb_data == NULL) {
+                smb2_set_error(smb2, "Failed to allocate sync_cb_data");
+                return -ENOMEM;
+        }
+
+	rc = smb2_link_async(smb2, oldpath, newpath,
+                               sync_generic_status_cb, cb_data);
+        if (rc < 0) {
+                goto out;
+	}
+
+	rc = wait_for_reply(smb2, cb_data);
+        if (rc < 0) {
+                cb_data->status = SMB2_STATUS_CANCELLED;
+                return rc;
+	}
+
+        rc = cb_data->status;
+ out:
+        free(cb_data);
+
+	return rc;
+}
+
 int smb2_statvfs(struct smb2_context *smb2, const char *path,
                  struct smb2_statvfs *st)
 {
@@ -789,7 +820,7 @@ static void readlink_cb(struct smb2_context *smb2, int status,
 {
         struct sync_cb_data *cb_data = private_data;
         struct sync_readlink_cb_data *rl_data = cb_data->ptr;
-        
+
         if (cb_data->status == SMB2_STATUS_CANCELLED) {
                 free(cb_data);
                 return;


### PR DESCRIPTION
I needed the ability to create hard links, so I added it, including a new `examples` file for testing.

I've tested this against my Synology NAS, and it works great. I've incorporated these changes into a utility I'm working on that let's you browse/search/manage hard links on an SMB share.
