### PR TITLE
Bound attacker-controlled label/name lengths in FILESYSTEM_INFO decoders

### DIFF
--- a/lib/smb2-data-filesystem-info.c
+++ b/lib/smb2-data-filesystem-info.c
@@ -62,12 +62,21 @@ smb2_decode_file_fs_volume_info(struct smb2_context *smb2,
         uint64_t t;
         const char *name;
 
+        if (vec->len < 18) {
+                return -1;
+        }
+
         smb2_get_uint64(vec,  0, &t);
         smb2_win_to_timeval(t, &fs->creation_time);
         smb2_get_uint32(vec,  8, &fs->volume_serial_number);
         smb2_get_uint32(vec, 12, &fs->volume_label_length);
         smb2_get_uint8(vec,  16, &fs->supports_objects);
         smb2_get_uint8(vec,  17, &fs->reserved);
+        /* volume_label_length is attacker-controlled; the label follows the
+         * 18-byte fixed header. Do not read past the received reply. */
+        if (fs->volume_label_length > vec->len - 18) {
+                return -1;
+        }
         name = smb2_utf16_to_utf8((uint16_t *)(void *)&vec->buf[18],
                             fs->volume_label_length / 2);
         fs->volume_label = smb2_alloc_data(smb2, memctx, strlen(name) + 1);
@@ -187,6 +196,11 @@ smb2_decode_file_fs_attribute_info(struct smb2_context *smb2,
         smb2_get_uint32(vec, 8, &name_len);
 
         if (name_len > 0) {
+                /* name_len is attacker-controlled; the name follows the 12-byte
+                 * fixed header. Bound it against the received reply. */
+                if (name_len > vec->len - 12) {
+                        return -1;
+                }
                 name = smb2_utf16_to_utf8((uint16_t *)(void *)&vec->buf[12], name_len / 2);
                 if (!name) {
 


### PR DESCRIPTION
As discussed by email — submitting as a PR so the credit lands in the commit.

**Bug (CWE-125, client-side, malicious/compromised SMB server):**
`smb2_decode_file_fs_volume_info()` and `smb2_decode_file_fs_attribute_info()`
(`lib/smb2-data-filesystem-info.c`) read a 32-bit label/name length from a QUERY
INFO (filesystem) reply and feed `length / 2` to `smb2_utf16_to_utf8()` without
bounding it against `vec->len`, so a short reply over-reads the heap.

**Fix:** reject replies shorter than the fixed header, and bound the label/name
length against the received reply before decoding.

**Verification:** built current master with an AddressSanitizer-instrumented
libsmb2 and the crafted volume-info / attribute-info replies — heap-buffer-overflow
before this change, clean after; valid replies still decode.

Reported privately on 2026-07-27. No CVE requested.