### PR TITLE
dcerpc: fix building on OpenBSD

### DIFF
--- a/libdcerpc/dcerpc-epm.c
+++ b/libdcerpc/dcerpc-epm.c
@@ -50,6 +50,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
 
 #include "compat.h"
 


### PR DESCRIPTION
```
libdcerpc/dcerpc-epm.c:1327:31: error: use of undeclared identifier 'AF_INET'
 1327 |                 if (inet_pton(AF_INET, ipv4, &addr) != 1) {
      |                               ^~~~~~~
libdcerpc/dcerpc-epm.c:1496:23: error: use of undeclared identifier 'AF_INET'
 1496 |         if (inet_ntop(AF_INET, rhs, ipbuf, sizeof(ipbuf)) == NULL) {
      |                       ^~~~~~~
2 errors generated.
```