### PR TITLE
smb3-seal: byte-swap SessionId for the wire in smb3_encrypt_pdu()

### DIFF
--- a/lib/smb3-seal.c
+++ b/lib/smb3-seal.c
@@ -106,7 +106,7 @@ smb3_encrypt_pdu(struct smb2_context *smb2,
         memcpy(&pdu->crypt[36], &u32, 4);
         u16 = htole16(SMB_ENCRYPTION_AES128_CCM);
         memcpy(&pdu->crypt[42], &u16, 2);
-        memcpy(&pdu->crypt[44], &smb2->session_id, 8);
+        *(uint64_t *)(void *)&pdu->crypt[44] = htole64(smb2->session_id);
 
         spl = 52;  /* transform header */
         for (tmp_pdu = pdu; tmp_pdu; tmp_pdu = tmp_pdu->next_compound) {


### PR DESCRIPTION
Fixes #477.

Per your feedback there -- switched from the scoped-variable version to a direct pointer-cast assignment:

```c
*(uint64_t *)(void *)&pdu->crypt[44] = htole64(smb2->session_id);
```

Re-tested on the same PPC hardware (Tiger iBook G4) with this exact form: `smb2_set_seal(ctx, 1)` connects successfully against both macOS's and Windows 11's standard SMB3 sharing.