### PR TITLE
fstat_cb_1: check status before dereferencing command_data

### DIFF
--- a/lib/libsmb2.c
+++ b/lib/libsmb2.c
@@ -1898,7 +1898,7 @@ fstat_cb_1(struct smb2_context *smb2, int status,
 {
         struct stat_cb_data *stat_data = private_data;
         struct smb2_query_info_reply *rep = command_data;
-        struct smb2_file_all_info *fs = rep->output_buffer;
+        struct smb2_file_all_info *fs;
         struct smb2_stat_64 *st = stat_data->st;
 
         if (status != SMB2_STATUS_SUCCESS) {
@@ -1907,6 +1907,13 @@ fstat_cb_1(struct smb2_context *smb2, int status,
                 free(stat_data);
                 return;
         }
+
+        /* command_data is NULL on any non-success completion -- notably
+         * smb2_destroy_context(), which drains the waitqueue by invoking every
+         * pending callback with (SMB2_STATUS_SHUTDOWN, NULL). Dereferencing it
+         * before the status check above segfaulted whenever a socket died with
+         * an fstat in flight. */
+        fs = rep->output_buffer;
 
         st->smb2_type = SMB2_TYPE_FILE;
         if (fs->basic.file_attributes & SMB2_FILE_ATTRIBUTE_DIRECTORY) {


### PR DESCRIPTION
`smb2_destroy_context()` drains its waitqueue by invoking every pending PDU's callback with `(SMB2_STATUS_SHUTDOWN, NULL, cb_data)` (lib/init.c). `fstat_cb_1()` reads `rep->output_buffer` one line above the status guard that would have returned safely, so any context destroyed with an fstat in flight dereferences NULL:

```c
struct smb2_query_info_reply *rep = command_data;      /* NULL on shutdown */
struct smb2_file_all_info *fs = rep->output_buffer;    /* dereferenced here */
struct smb2_stat_64 *st = stat_data->st;

if (status != SMB2_STATUS_SUCCESS) { ... return; }     /* one line too late */
```

This patch declares `fs` and assigns it after the status check. No behavior change on the success path.

`fstat_cb_1` appears to be the only callback in `libsmb2.c` that dereferences `command_data` ahead of its status check — the others do so inside the success branch.

Scope of the evidence, stated precisely: the ordering problem above is static, readable in the source. Separately, we have a symbolicated crash stack from an iOS device that ends at this exact line, reached via `smb2_destroy_context` → `fstat_cb_1` after a socket died with an fstat pending. What I cannot yet claim is how often it fires in the wild — our attribution of specific user-visible crashes to it is still unverified, so please treat this as a correctness fix on the code as written rather than a report of a quantified field failure. Marked draft until we have finished verifying on our side.